### PR TITLE
⚡ Bolt: Add SQLite indices to optimize catalog search

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-04-14 - SQLite Temporary B-Tree Sorting
+**Learning:** Found an O(N log N) sorting overhead for every catalog query (popular, trending, new) because `catalog_packs` had no indices covering `public`, `likes`, `view_count`, and `added_at`.
+**Action:** Adding covering indices (`public, likes DESC`, etc.) turns this into an O(log N) lookup and avoids temporary B-Trees during sorting.

--- a/infra/db.py
+++ b/infra/db.py
@@ -76,6 +76,12 @@ def init_db() -> None:
         )
         """
     )
+    # ⚡ Bolt Optimization: Add covering indices for common catalog_search modes
+    # Impact: Turns O(N log N) full table scans and temporary B-tree sorting into O(log N) lookups
+    c.execute("CREATE INDEX IF NOT EXISTS idx_catalog_packs_popular ON catalog_packs (public, likes DESC)")
+    c.execute("CREATE INDEX IF NOT EXISTS idx_catalog_packs_trending ON catalog_packs (public, view_count DESC, likes DESC)")
+    c.execute("CREATE INDEX IF NOT EXISTS idx_catalog_packs_new ON catalog_packs (public, added_at DESC)")
+
     conn.commit()
     conn.close()
 

--- a/test_db.py
+++ b/test_db.py
@@ -1,0 +1,26 @@
+import sqlite3
+
+conn = sqlite3.connect(':memory:')
+c = conn.cursor()
+c.execute("""
+    CREATE TABLE IF NOT EXISTS catalog_packs (
+        id          INTEGER PRIMARY KEY AUTOINCREMENT,
+        name        TEXT    UNIQUE NOT NULL,
+        title       TEXT    NOT NULL,
+        description TEXT    DEFAULT '',
+        type        TEXT    DEFAULT 'image',
+        public      INTEGER DEFAULT 1,
+        safe        INTEGER DEFAULT 1,
+        likes       INTEGER DEFAULT 0,
+        dislikes    INTEGER DEFAULT 0,
+        view_count  INTEGER DEFAULT 0,
+        added_at    INTEGER NOT NULL,
+        added_by    INTEGER
+    )
+""")
+
+c.execute("CREATE INDEX IF NOT EXISTS idx_catalog_packs_popular ON catalog_packs (public, likes DESC)")
+c.execute("CREATE INDEX IF NOT EXISTS idx_catalog_packs_trending ON catalog_packs (public, view_count DESC, likes DESC)")
+c.execute("CREATE INDEX IF NOT EXISTS idx_catalog_packs_new ON catalog_packs (public, added_at DESC)")
+
+print("All indices created successfully.")

--- a/tests/test_stixmagic_settings.py
+++ b/tests/test_stixmagic_settings.py
@@ -34,7 +34,7 @@ class TestGetSettings(unittest.TestCase):
             "STIXMAGIC_DB_PATH": "test.db",
             "STIXMAGIC_PUBLIC_BASE_URL": "https://example.com",
             "TELEGRAM_BOT_MODE": "polling",
-
+        }
         s = self._get_settings_with_env(env)
         self.assertEqual(s.telegram_bot_token, "123:abc")
         self.assertEqual(s.telegram_bot_username, "mybot")
@@ -44,7 +44,7 @@ class TestGetSettings(unittest.TestCase):
         self.assertEqual(s.bot_mode, "polling")
 
     def test_token_falls_back_to_env_suffix(self):
-        env = {"APP_ENV": "development", "BOT_TOKEN_DEV": "123:abc"
+        env = {"APP_ENV": "development", "BOT_TOKEN_DEV": "123:abc"}
         s = self._get_settings_with_env(env)
         self.assertEqual(s.telegram_bot_token, "123:abc")
 

--- a/tests/test_stixmagic_settings.py
+++ b/tests/test_stixmagic_settings.py
@@ -72,7 +72,7 @@ class TestGetSettings(unittest.TestCase):
         self.assertEqual(s.public_base_url, "")
 
     def test_database_path_default_is_bot_db(self):
-        env = {, "TELEGRAM_BOT_TOKEN": "dummy"}
+        env = {"TELEGRAM_BOT_TOKEN": "dummy"}
         s = self._get_settings_with_env(env)
         self.assertEqual(s.database_path, "bot.db")
 

--- a/tests/test_stixmagic_settings.py
+++ b/tests/test_stixmagic_settings.py
@@ -58,12 +58,12 @@ class TestGetSettings(unittest.TestCase):
             "APP_ENV": "production",
             "TELEGRAM_BOT_TOKEN": "111:direct",
             "BOT_TOKEN_PROD": "222:fallback",
-
+        }
         s = self._get_settings_with_env(env)
         self.assertEqual(s.telegram_bot_token, "111:direct")
 
     def test_defaults_when_optional_vars_absent(self):
-        env = {, "TELEGRAM_BOT_TOKEN": "dummy"}
+        env = {"TELEGRAM_BOT_TOKEN": "dummy"}
         s = self._get_settings_with_env(env)
         self.assertEqual(s.telegram_bot_token, "dummy")
         self.assertEqual(s.stixmagic_api_key, "")


### PR DESCRIPTION
💡 What: Added covering indices to the `catalog_packs` table in `infra/db.py` to optimize the frequent `catalog_search` queries (popular, trending, new).
🎯 Why: Analyzing the `EXPLAIN QUERY PLAN` for these queries revealed they were performing full table scans (`SCAN catalog_packs`) and using temporary B-trees (`USE TEMP B-TREE FOR ORDER BY`) to sort the results. As the catalog grows, this would become a significant O(N log N) backend bottleneck.
📊 Impact: Turns O(N log N) sorting overhead into an O(log N) lookup and O(1) step.
🔬 Measurement: Verify via `EXPLAIN QUERY PLAN SELECT * FROM catalog_packs WHERE public = 1 ORDER BY likes DESC LIMIT 25 OFFSET 0;` which will now use `SEARCH catalog_packs USING INDEX`.

---
*PR created automatically by Jules for task [16827810412346668673](https://jules.google.com/task/16827810412346668673) started by @FriskyDevelopments*