### PR TITLE
⚡ Bolt: optimize _validate_packs_async using asyncio.gather

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,9 @@
 ## 2024-04-16 - Memory Inefficiency of Python Array Slicing for Pagination
 **Learning:** Found that `api.py` was pulling the entire result set of user packs (`/api/packs/<user_id>`) and search results (`/api/search`) into a Python list and *then* applying pagination slicing using `paginate()`. This caused `O(N)` memory usage and query time for queries returning large sets (e.g. 100k rows took >0.3s).
 **Action:** Replace `SELECT * ...` coupled with Python array slicing with `SELECT COUNT(*)` followed by `SELECT * ... LIMIT ? OFFSET ?` to reduce complexity from `O(N)` to `O(limit)`. This yielded up to ~30x performance improvement.
+## 2024-04-17 - Sequential I/O causing N+1 performance bottleneck
+**Learning:** Found that `_validate_packs_async` in `api.py` was awaiting `bot.get_sticker_set(name)` sequentially in a loop for each pack. For users with many packs, this blocking caused significant delays and poor overall API performance since each request blocked the next.
+**Action:** Always batch independent I/O tasks using `asyncio.gather()` inside async functions to execute network calls concurrently, reducing total time from `O(N)` to `O(1)` request time.
+## 2024-04-18 - Rate Limits and Unbounded Async Gather
+**Learning:** While `asyncio.gather()` provides significant performance boost for I/O bound tasks, an unbounded gather can trigger API rate limits (e.g., HTTP 429). In code with broad error handlers (like deleting data on `except Exception:`), this can result in catastrophic silent data deletion.
+**Action:** Always wrap concurrent network requests in an `asyncio.Semaphore` when using `asyncio.gather()` on an unbounded set of items to prevent rate limit exceptions from triggering unintended fallback logic.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,7 +9,7 @@
 **Action:** Replace `SELECT * ...` coupled with Python array slicing with `SELECT COUNT(*)` followed by `SELECT * ... LIMIT ? OFFSET ?` to reduce complexity from `O(N)` to `O(limit)`. This yielded up to ~30x performance improvement.
 ## 2024-04-17 - Sequential I/O causing N+1 performance bottleneck
 **Learning:** Found that `_validate_packs_async` in `api.py` was awaiting `bot.get_sticker_set(name)` sequentially in a loop for each pack. For users with many packs, this blocking caused significant delays and poor overall API performance since each request blocked the next.
-**Action:** Always batch independent I/O tasks using `asyncio.gather()` inside async functions to execute network calls concurrently, reducing total time from `O(N)` to `O(1)` request time.
+**Action:** Always batch independent I/O tasks using `asyncio.gather()` inside async functions to execute network calls concurrently, reducing wall-clock time from fully sequential `O(N)` waits toward roughly `O(N / concurrency_limit)` for I/O-bound work, while total work remains `O(N)`.
 ## 2024-04-18 - Rate Limits and Unbounded Async Gather
 **Learning:** While `asyncio.gather()` provides significant performance boost for I/O bound tasks, an unbounded gather can trigger API rate limits (e.g., HTTP 429). In code with broad error handlers (like deleting data on `except Exception:`), this can result in catastrophic silent data deletion.
 **Action:** Always wrap concurrent network requests in an `asyncio.Semaphore` when using `asyncio.gather()` on an unbounded set of items to prevent rate limit exceptions from triggering unintended fallback logic.

--- a/api.py
+++ b/api.py
@@ -31,7 +31,7 @@ SETTINGS = get_settings()
 API_KEY = SETTINGS.stixmagic_api_key
 PAGE_SIZE = 20
 PACK_VALIDATION_CONCURRENCY = 10
-_MISSING_STICKER_SET_ERROR_MARKERS = (
+_TELEGRAM_MISSING_PACK_MARKERS = (
     "sticker set not found",
     "sticker set name is invalid",
 )
@@ -319,7 +319,7 @@ def _is_missing_sticker_set_error(exc: Exception, bad_request_cls: type[Exceptio
     if not isinstance(exc, bad_request_cls):
         return False
     message = str(exc).lower()
-    return any(marker in message for marker in _MISSING_STICKER_SET_ERROR_MARKERS)
+    return any(marker in message for marker in _TELEGRAM_MISSING_PACK_MARKERS)
 
 
 async def _validate_packs_async(token, user_id):

--- a/api.py
+++ b/api.py
@@ -313,20 +313,35 @@ async def _validate_packs_async(token, user_id):
         c = conn.cursor()
         c.execute("SELECT name, title FROM packs WHERE user_id = ? ORDER BY id", (user_id,))
         rows = c.fetchall()
+        # ⚡ Bolt Optimization: Concurrently fetch all sticker sets with a concurrency limit
+        # Impact: Reduces request time significantly without triggering Telegram API rate limits that would cause silent data deletion
+        sem = asyncio.Semaphore(10)
+
+        async def fetch_pack(row):
+            async with sem:
+                name, title = row["name"], row["title"]
+                try:
+                    ss = await bot.get_sticker_set(name)
+                    return {"name": name, "old_title": title, "new_title": ss.title, "found": True}
+                except Exception:
+                    return {"name": name, "old_title": title, "new_title": None, "found": False}
+
+        results = await asyncio.gather(*(fetch_pack(row) for row in rows))
+
         valid = []
-        for row in rows:
-            name, title = row["name"], row["title"]
-            try:
-                ss = await bot.get_sticker_set(name)
-                if ss.title != title:
+        for res in results:
+            name = res["name"]
+            if res["found"]:
+                title = res["old_title"]
+                if res["new_title"] != title:
                     c.execute(
                         "UPDATE packs SET title = ? WHERE user_id = ? AND name = ?",
-                        (ss.title, user_id, name)
+                        (res["new_title"], user_id, name)
                     )
                     conn.commit()
-                    title = ss.title
+                    title = res["new_title"]
                 valid.append({"name": name, "title": title, "link": f"https://t.me/addstickers/{name}"})
-            except Exception:
+            else:
                 c.execute("DELETE FROM packs WHERE user_id = ? AND name = ?", (user_id, name))
                 conn.commit()
         conn.close()

--- a/api.py
+++ b/api.py
@@ -309,9 +309,14 @@ def _run_async(coro):
         loop.close()
 
 
-def _is_missing_sticker_set_error(exc: Exception) -> bool:
-    """Return True only for Telegram BadRequest errors that indicate a missing pack."""
-    if exc.__class__.__name__ != "BadRequest":
+def _is_missing_sticker_set_error(exc: Exception, bad_request_cls: type[Exception]) -> bool:
+    """Return True only for Telegram BadRequest errors that indicate a missing pack.
+
+    `bad_request_cls` is passed in by the caller so tests can provide a stub class.
+    All non-BadRequest exceptions return False and are treated as non-fatal validation failures.
+    Matching is case-insensitive against known missing-pack message markers.
+    """
+    if not isinstance(exc, bad_request_cls):
         return False
     message = str(exc).lower()
     return any(marker in message for marker in _MISSING_STICKER_SET_ERROR_MARKERS)
@@ -320,6 +325,7 @@ def _is_missing_sticker_set_error(exc: Exception) -> bool:
 async def _validate_packs_async(token, user_id):
     """Validate all DB packs against Telegram; prune deleted, sync renamed titles."""
     from telegram import Bot as TelegramBot
+    from telegram.error import BadRequest as TelegramBadRequest
     bot = TelegramBot(token=token)
     try:
         conn = get_db()
@@ -336,9 +342,9 @@ async def _validate_packs_async(token, user_id):
                         ss = await bot.get_sticker_set(name)
                         return {"name": name, "old_title": title, "new_title": ss.title, "status": "found"}
                     except Exception as exc:
-                        if _is_missing_sticker_set_error(exc):
+                        if _is_missing_sticker_set_error(exc, TelegramBadRequest):
                             return {"name": name, "old_title": title, "new_title": None, "status": "missing"}
-                        logger.warning("Temporary sticker-set validation failure for %s: %s", name, exc)
+                        logger.warning("Non-fatal sticker-set validation failure for %s: %s", name, exc)
                         return {"name": name, "old_title": title, "new_title": None, "status": "transient"}
 
             results = await asyncio.gather(*(fetch_pack(row) for row in rows))

--- a/api.py
+++ b/api.py
@@ -30,6 +30,11 @@ app = Flask(__name__, static_folder="static")
 SETTINGS = get_settings()
 API_KEY = SETTINGS.stixmagic_api_key
 PAGE_SIZE = 20
+PACK_VALIDATION_CONCURRENCY = 10
+_MISSING_STICKER_SET_ERROR_MARKERS = (
+    "sticker set not found",
+    "sticker set name is invalid",
+)
 if SETTINGS.webhook_secret:
     app.secret_key = SETTINGS.webhook_secret
 else:
@@ -304,48 +309,64 @@ def _run_async(coro):
         loop.close()
 
 
+def _is_missing_sticker_set_error(exc: Exception) -> bool:
+    """Return True only for Telegram BadRequest errors that indicate a missing pack."""
+    if exc.__class__.__name__ != "BadRequest":
+        return False
+    message = str(exc).lower()
+    return any(marker in message for marker in _MISSING_STICKER_SET_ERROR_MARKERS)
+
+
 async def _validate_packs_async(token, user_id):
     """Validate all DB packs against Telegram; prune deleted, sync renamed titles."""
     from telegram import Bot as TelegramBot
     bot = TelegramBot(token=token)
     try:
         conn = get_db()
-        c = conn.cursor()
-        c.execute("SELECT name, title FROM packs WHERE user_id = ? ORDER BY id", (user_id,))
-        rows = c.fetchall()
-        # ⚡ Bolt Optimization: Concurrently fetch all sticker sets with a concurrency limit
-        # Impact: Reduces request time significantly without triggering Telegram API rate limits that would cause silent data deletion
-        sem = asyncio.Semaphore(10)
+        try:
+            c = conn.cursor()
+            c.execute("SELECT name, title FROM packs WHERE user_id = ? ORDER BY id", (user_id,))
+            rows = c.fetchall()
+            sem = asyncio.Semaphore(PACK_VALIDATION_CONCURRENCY)
 
-        async def fetch_pack(row):
-            async with sem:
-                name, title = row["name"], row["title"]
-                try:
-                    ss = await bot.get_sticker_set(name)
-                    return {"name": name, "old_title": title, "new_title": ss.title, "found": True}
-                except Exception:
-                    return {"name": name, "old_title": title, "new_title": None, "found": False}
+            async def fetch_pack(row):
+                async with sem:
+                    name, title = row["name"], row["title"]
+                    try:
+                        ss = await bot.get_sticker_set(name)
+                        return {"name": name, "old_title": title, "new_title": ss.title, "status": "found"}
+                    except Exception as exc:
+                        if _is_missing_sticker_set_error(exc):
+                            return {"name": name, "old_title": title, "new_title": None, "status": "missing"}
+                        logger.warning("Temporary sticker-set validation failure for %s: %s", name, exc)
+                        return {"name": name, "old_title": title, "new_title": None, "status": "transient"}
 
-        results = await asyncio.gather(*(fetch_pack(row) for row in rows))
+            results = await asyncio.gather(*(fetch_pack(row) for row in rows))
 
-        valid = []
-        for res in results:
-            name = res["name"]
-            if res["found"]:
-                title = res["old_title"]
-                if res["new_title"] != title:
-                    c.execute(
-                        "UPDATE packs SET title = ? WHERE user_id = ? AND name = ?",
-                        (res["new_title"], user_id, name)
-                    )
+            valid = []
+            for res in results:
+                name = res["name"]
+                status = res["status"]
+                if status == "found":
+                    title = res["old_title"]
+                    if res["new_title"] != title:
+                        c.execute(
+                            "UPDATE packs SET title = ? WHERE user_id = ? AND name = ?",
+                            (res["new_title"], user_id, name)
+                        )
+                        conn.commit()
+                        title = res["new_title"]
+                    valid.append({"name": name, "title": title, "link": f"https://t.me/addstickers/{name}"})
+                elif status == "missing":
+                    c.execute("DELETE FROM packs WHERE user_id = ? AND name = ?", (user_id, name))
                     conn.commit()
-                    title = res["new_title"]
-                valid.append({"name": name, "title": title, "link": f"https://t.me/addstickers/{name}"})
-            else:
-                c.execute("DELETE FROM packs WHERE user_id = ? AND name = ?", (user_id, name))
-                conn.commit()
-        conn.close()
-        return valid
+                else:
+                    valid.append(
+                        {"name": name, "title": res["old_title"], "link": f"https://t.me/addstickers/{name}"}
+                    )
+            return valid
+        finally:
+            conn.close()
     finally:
         await bot.close()
 

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -31,7 +31,7 @@ FAKE_USER = {"id": 42, "first_name": "Alice", "username": "alice"}
 
 
 class BadRequest(Exception):
-    """Minimal test-only stub that mimics python-telegram-bot's telegram.error.BadRequest."""
+    """Module-level test helper that mimics python-telegram-bot's telegram.error.BadRequest."""
     pass
 
 
@@ -570,6 +570,10 @@ def _run_async(coro):
     return asyncio.get_event_loop().run_until_complete(coro)
 
 
+def _sql_calls_containing(calls, sql_fragment):
+    return [c for c in calls if sql_fragment in c.args[0]]
+
+
 class TestValidatePacksAsync(unittest.TestCase):
     """_validate_packs_async – connection-reuse and validation logic."""
 
@@ -725,7 +729,7 @@ class TestValidatePacksAsync(unittest.TestCase):
             _run_async(_validate_packs_async("fake:token", 7))
 
         calls = cursor.execute.call_args_list
-        delete_calls = [c for c in calls if "DELETE" in c[0][0]]
+        delete_calls = _sql_calls_containing(calls, "DELETE")
         self.assertEqual(len(delete_calls), 1)
         delete_args = delete_calls[0][0]
         self.assertIn("DELETE FROM packs", delete_args[0])
@@ -756,7 +760,7 @@ class TestValidatePacksAsync(unittest.TestCase):
 
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["name"], "flaky")
-        delete_calls = [c for c in cursor.execute.call_args_list if "DELETE" in c[0][0]]
+        delete_calls = _sql_calls_containing(cursor.execute.call_args_list, "DELETE")
         self.assertEqual(delete_calls, [])
 
     # ── single-connection guarantee (N+1 fix) ─────────────────

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -31,6 +31,7 @@ FAKE_USER = {"id": 42, "first_name": "Alice", "username": "alice"}
 
 
 class BadRequest(Exception):
+    """Minimal test-only stub that mimics python-telegram-bot's telegram.error.BadRequest."""
     pass
 
 
@@ -535,8 +536,14 @@ def _ensure_api_importable():
     if "telegram" not in sys.modules:
         telegram_stub = MagicMock()
         telegram_stub.__name__ = "telegram"
+        telegram_stub.__path__ = []
         telegram_stub.Bot = MagicMock()
         sys.modules["telegram"] = telegram_stub
+    if "telegram.error" not in sys.modules:
+        telegram_error_stub = MagicMock()
+        telegram_error_stub.BadRequest = BadRequest
+        sys.modules["telegram.error"] = telegram_error_stub
+    sys.modules["telegram"].error = sys.modules["telegram.error"]
 
     for mod in ("config", "config.runtime", "moderation"):
         if mod not in sys.modules:
@@ -718,7 +725,7 @@ class TestValidatePacksAsync(unittest.TestCase):
             _run_async(_validate_packs_async("fake:token", 7))
 
         calls = cursor.execute.call_args_list
-        delete_calls = [c for c in calls if "DELETE" in str(c)]
+        delete_calls = [c for c in calls if "DELETE" in c[0][0]]
         self.assertEqual(len(delete_calls), 1)
         delete_args = delete_calls[0][0]
         self.assertIn("DELETE FROM packs", delete_args[0])
@@ -749,7 +756,7 @@ class TestValidatePacksAsync(unittest.TestCase):
 
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["name"], "flaky")
-        delete_calls = [c for c in cursor.execute.call_args_list if "DELETE" in str(c)]
+        delete_calls = [c for c in cursor.execute.call_args_list if "DELETE" in c[0][0]]
         self.assertEqual(delete_calls, [])
 
     # ── single-connection guarantee (N+1 fix) ─────────────────
@@ -830,9 +837,9 @@ class TestValidatePacksAsync(unittest.TestCase):
         conn.close.assert_called_once()
 
     def test_conn_close_called_when_gather_raises(self):
-        bad_row = MagicMock()
-        bad_row.__getitem__.side_effect = KeyError("name")
-        rows = [bad_row]
+        failing_row = MagicMock()
+        failing_row.__getitem__.side_effect = KeyError("name")
+        rows = [failing_row]
         conn, cursor = self._make_conn(rows)
         bot = self._make_bot(sticker_sets={"pack1": "Pack One"})
 

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -30,6 +30,10 @@ FAKE_BOT_TOKEN = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef_gh"
 FAKE_USER = {"id": 42, "first_name": "Alice", "username": "alice"}
 
 
+class BadRequest(Exception):
+    pass
+
+
 def _build_init_data(bot_token: str, user: dict, auth_date: int | None = None) -> str:
     if auth_date is None:
         auth_date = int(time.time())
@@ -570,7 +574,7 @@ class TestValidatePacksAsync(unittest.TestCase):
             import importlib
             sys.modules["api"] = importlib.import_module("api")
 
-    def _make_bot(self, sticker_sets=None, raise_for=None):
+    def _make_bot(self, sticker_sets=None, raise_for_missing=None, raise_for_transient=None):
         """
         Build an AsyncMock Bot.
 
@@ -581,8 +585,10 @@ class TestValidatePacksAsync(unittest.TestCase):
         bot.close = AsyncMock()
 
         async def _get_sticker_set(name):
-            if raise_for and name in raise_for:
-                raise Exception(f"Pack {name} not found")
+            if raise_for_missing and name in raise_for_missing:
+                raise BadRequest("Sticker set not found")
+            if raise_for_transient and name in raise_for_transient:
+                raise RuntimeError(f"Temporary failure for {name}")
             ss = MagicMock()
             ss.title = (sticker_sets or {}).get(name, name)
             return ss
@@ -692,7 +698,7 @@ class TestValidatePacksAsync(unittest.TestCase):
     def test_missing_pack_deleted_from_db(self):
         row = _make_db_row("deadpack", "Dead Pack")
         conn, cursor = self._make_conn([row])
-        bot = self._make_bot(raise_for={"deadpack"})
+        bot = self._make_bot(raise_for_missing={"deadpack"})
 
         with patch("api.get_db", return_value=conn), \
              patch("telegram.Bot", return_value=bot):
@@ -704,7 +710,7 @@ class TestValidatePacksAsync(unittest.TestCase):
     def test_missing_pack_executes_delete_on_same_cursor(self):
         row = _make_db_row("deadpack", "Dead Pack")
         conn, cursor = self._make_conn([row])
-        bot = self._make_bot(raise_for={"deadpack"})
+        bot = self._make_bot(raise_for_missing={"deadpack"})
 
         with patch("api.get_db", return_value=conn), \
              patch("telegram.Bot", return_value=bot):
@@ -722,7 +728,7 @@ class TestValidatePacksAsync(unittest.TestCase):
     def test_missing_pack_commits_delete_on_existing_connection(self):
         row = _make_db_row("deadpack", "Dead Pack")
         conn, cursor = self._make_conn([row])
-        bot = self._make_bot(raise_for={"deadpack"})
+        bot = self._make_bot(raise_for_missing={"deadpack"})
 
         with patch("api.get_db", return_value=conn), \
              patch("telegram.Bot", return_value=bot):
@@ -730,6 +736,21 @@ class TestValidatePacksAsync(unittest.TestCase):
             _run_async(_validate_packs_async("fake:token", 1))
 
         conn.commit.assert_called()
+
+    def test_transient_error_keeps_pack_and_skips_delete(self):
+        row = _make_db_row("flaky", "Flaky Pack")
+        conn, cursor = self._make_conn([row])
+        bot = self._make_bot(raise_for_transient={"flaky"})
+
+        with patch("api.get_db", return_value=conn), \
+             patch("telegram.Bot", return_value=bot):
+            from api import _validate_packs_async
+            result = _run_async(_validate_packs_async("fake:token", 1))
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name"], "flaky")
+        delete_calls = [c for c in cursor.execute.call_args_list if "DELETE" in str(c)]
+        self.assertEqual(delete_calls, [])
 
     # ── single-connection guarantee (N+1 fix) ─────────────────
 
@@ -756,7 +777,7 @@ class TestValidatePacksAsync(unittest.TestCase):
         """Deleting a stale pack must not open a second connection."""
         rows = [_make_db_row("deadpack", "Dead Pack")]
         conn, cursor = self._make_conn(rows)
-        bot = self._make_bot(raise_for={"deadpack"})
+        bot = self._make_bot(raise_for_missing={"deadpack"})
 
         with patch("api.get_db", return_value=conn) as mock_get_db, \
              patch("telegram.Bot", return_value=bot):
@@ -799,12 +820,27 @@ class TestValidatePacksAsync(unittest.TestCase):
             _make_db_row("dead2", "Dead Two"),
         ]
         conn, cursor = self._make_conn(rows)
-        bot = self._make_bot(raise_for={"dead1", "dead2"})
+        bot = self._make_bot(raise_for_missing={"dead1", "dead2"})
 
         with patch("api.get_db", return_value=conn), \
              patch("telegram.Bot", return_value=bot):
             from api import _validate_packs_async
             _run_async(_validate_packs_async("fake:token", 1))
+
+        conn.close.assert_called_once()
+
+    def test_conn_close_called_when_gather_raises(self):
+        bad_row = MagicMock()
+        bad_row.__getitem__.side_effect = KeyError("name")
+        rows = [bad_row]
+        conn, cursor = self._make_conn(rows)
+        bot = self._make_bot(sticker_sets={"pack1": "Pack One"})
+
+        with patch("api.get_db", return_value=conn), \
+             patch("telegram.Bot", return_value=bot):
+            from api import _validate_packs_async
+            with self.assertRaises(KeyError):
+                _run_async(_validate_packs_async("fake:token", 1))
 
         conn.close.assert_called_once()
 
@@ -825,7 +861,7 @@ class TestValidatePacksAsync(unittest.TestCase):
         """bot.close() must be awaited even when pack validation fails."""
         rows = [_make_db_row("deadpack", "Dead")]
         conn, cursor = self._make_conn(rows)
-        bot = self._make_bot(raise_for={"deadpack"})
+        bot = self._make_bot(raise_for_missing={"deadpack"})
 
         with patch("api.get_db", return_value=conn), \
              patch("telegram.Bot", return_value=bot):
@@ -846,7 +882,7 @@ class TestValidatePacksAsync(unittest.TestCase):
         conn, cursor = self._make_conn(rows)
         bot = self._make_bot(
             sticker_sets={"good": "Good Pack", "renamed": "New Name"},
-            raise_for={"dead"},
+            raise_for_missing={"dead"},
         )
 
         with patch("api.get_db", return_value=conn) as mock_get_db, \


### PR DESCRIPTION
⚡ Bolt: optimize `_validate_packs_async` using `asyncio.gather`

💡 What: Refactored `_validate_packs_async` to fetch Telegram sticker sets concurrently instead of sequentially using `asyncio.gather()`, safely bounded by an `asyncio.Semaphore(10)`. Database updates are still done sequentially after results are returned.
🎯 Why: Iterating over packs and awaiting API requests sequentially caused N+1 network performance bottlenecks for users with many packs.
📊 Impact: Total request time reduces significantly by executing API calls concurrently without triggering rate limits that could lead to data deletion.
🔬 Measurement: Verify existing tests in `tests/test_api_helpers.py` pass without regressions.

---
*PR created automatically by Jules for task [239626608853134722](https://jules.google.com/task/239626608853134722) started by @FriskyDevelopments*