### PR TITLE
⚡ Bolt: Optimize `is_new_user` logic to avoid full table scans

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -20,3 +20,6 @@
 ## 2024-05-19 - Expensive External Network Calls in Loops
 **Learning:** Found that `/api/miniapp/packs` calls `bot.get_sticker_set(name)` for every pack the user owns to validate their status. For a user with 50 packs, this triggered 50 concurrent network requests to Telegram on *every single page load*, resulting in severe performance degradation and triggering HTTP 429 rate limit exceptions, which in turn could lead to accidental deletion of their data in fallback blocks.
 **Action:** Implemented a short-lived memory cache (`_TG_PACK_CACHE` with a 5-minute TTL) for Telegram sticker set network requests. This ensures that validation is only performed periodically, reducing network latency by ~99% on subsequent loads and protecting the system and user data against rate limits.
+## 2024-05-20 - is_new_user Table Scans
+**Learning:** Found that `is_new_user` in `infra/db.py` was issuing two `COUNT(*)` queries that executed full table scans on `packs` and `user_settings`. Because the tables can be very large, evaluating `COUNT(*)` performs poorly since it has to check every row.
+**Action:** Replaced the two `COUNT(*)` queries with a single `SELECT 1 WHERE EXISTS (SELECT 1 ...) OR EXISTS (SELECT 1 ...)` query. This changes the time complexity from `O(N)` to `O(1)` as `EXISTS` returns `True` upon finding the first match.

--- a/infra/db.py
+++ b/infra/db.py
@@ -210,12 +210,16 @@ def is_new_user(user_id: int) -> bool:
     """
     conn = sqlite3.connect(_db_file())
     c = conn.cursor()
-    c.execute("SELECT COUNT(*) FROM packs WHERE user_id = ?", (user_id,))
-    packs = c.fetchone()[0]
-    c.execute("SELECT COUNT(*) FROM user_settings WHERE user_id = ?", (user_id,))
-    settings = c.fetchone()[0]
+    # ⚡ Bolt Optimization: Replace COUNT(*) table scans with EXISTS query
+    # Impact: Improves performance from O(N) to O(1) by stopping at the first match instead of counting all rows
+    c.execute(
+        "SELECT 1 WHERE EXISTS (SELECT 1 FROM packs WHERE user_id = ?) "
+        "OR EXISTS (SELECT 1 FROM user_settings WHERE user_id = ?)",
+        (user_id, user_id)
+    )
+    result = c.fetchone()
     conn.close()
-    return packs == 0 and settings == 0
+    return result is None
 
 
 # ── Catalog CRUD ──────────────────────────────────────────────


### PR DESCRIPTION
💡 **What**: Refactored the `is_new_user` function in `infra/db.py` to use a single `EXISTS` SQL query instead of two separate `SELECT COUNT(*)` queries.
🎯 **Why**: Executing `COUNT(*)` necessitates a full table scan which scales poorly with large data volumes (O(N)).
📊 **Impact**: Reduces query time complexity from `O(N)` to `O(1)` since `EXISTS` terminates the search upon the first match.
🔬 **Measurement**: Verified the functionality of `is_new_user` by running `tests/test_infra_db.py`.

---
*PR created automatically by Jules for task [1821782409612239860](https://jules.google.com/task/1821782409612239860) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk SQL refactor confined to `infra/db.py`; behavior should be equivalent but relies on correct handling of `fetchone()` returning `None` vs a row.
> 
> **Overview**
> **Improves `is_new_user` performance** by replacing two `COUNT(*)` queries on `packs` and `user_settings` with a single `EXISTS`-based query, avoiding full table scans on large tables.
> 
> Updates `.jules/bolt.md` with a new performance note documenting the table-scan finding and the `EXISTS` fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cddb6629e6424931b05bfb4bf9fe01b21a13b7e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->