### PR TITLE
⚡ Bolt: Cache Telegram API calls in bot handlers to reduce latency

### DIFF
--- a/main.py
+++ b/main.py
@@ -96,9 +96,12 @@ async def validate_and_sync_packs(bot, user_id):
                 ss = await bot.get_sticker_set(name)
                 _TG_PACK_CACHE[name] = (now, ss.title, "valid")
                 return {"name": name, "title": ss.title, "old_title": title, "status": "valid"}
-            except Exception:
+            except BadRequest:
                 _TG_PACK_CACHE[name] = (now, title, "deleted")
                 return {"name": name, "title": title, "old_title": title, "status": "deleted"}
+            except Exception as e:
+                logger.warning(f"Could not validate pack {name}: {e}")
+                return {"name": name, "title": title, "old_title": title, "status": "unknown"}
 
     tasks = [_validate_single_pack(name, title) for name, title in packs]
     results = await asyncio.gather(*tasks)
@@ -110,7 +113,7 @@ async def validate_and_sync_packs(bot, user_id):
             if title != old_title:
                 update_pack_title_in_db(user_id, name, title)
             valid.append((name, title))
-        else:
+        elif status == "deleted":
             delete_pack_from_db(user_id, name)
             logger.info(f"Pruned stale pack {name} for user {user_id}")
 

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import logging
 import random
 import string
 import threading
+import time
 
 from config.runtime import ConfigError, get_settings
 
@@ -66,6 +67,9 @@ init_db()
 core_engine = StixCoreEngine()
 telegram_adapter = TelegramStixAdapter(core_engine)
 
+_TG_PACK_CACHE = {}  # {name: (timestamp, title, status)}
+_TG_PACK_CACHE_TTL = 300  # 5 minutes
+
 async def validate_and_sync_packs(bot, user_id):
     """Check each DB pack against Telegram. Prune deleted packs, sync renamed titles."""
     packs = get_user_packs(user_id)
@@ -75,11 +79,25 @@ async def validate_and_sync_packs(bot, user_id):
     sem = asyncio.Semaphore(5)
 
     async def _validate_single_pack(name, title):
+        now = time.time()
+
+        # Prevent memory leaks
+        if len(_TG_PACK_CACHE) > 1000:
+            _TG_PACK_CACHE.clear()
+
+        # ⚡ Bolt Optimization: Cache expensive Telegram API calls per pack for 5 minutes
+        # Impact: Drastically reduces network latency and avoids 429 errors when reloading bot menus (e.g. Grimoire)
+        if name in _TG_PACK_CACHE and now - _TG_PACK_CACHE[name][0] < _TG_PACK_CACHE_TTL:
+            _, cached_title, status = _TG_PACK_CACHE[name]
+            return {"name": name, "title": cached_title, "old_title": title, "status": status}
+
         async with sem:
             try:
                 ss = await bot.get_sticker_set(name)
+                _TG_PACK_CACHE[name] = (now, ss.title, "valid")
                 return {"name": name, "title": ss.title, "old_title": title, "status": "valid"}
             except Exception:
+                _TG_PACK_CACHE[name] = (now, title, "deleted")
                 return {"name": name, "title": title, "old_title": title, "status": "deleted"}
 
     tasks = [_validate_single_pack(name, title) for name, title in packs]

--- a/main.py
+++ b/main.py
@@ -74,16 +74,33 @@ async def validate_and_sync_packs(bot, user_id):
     """Check each DB pack against Telegram. Prune deleted packs, sync renamed titles."""
     packs = get_user_packs(user_id)
 
+    # Prevent memory leaks without dropping cached packs needed by this validation batch.
+    now = time.time()
+    pack_names = {name for name, _ in packs}
+    if len(_TG_PACK_CACHE) > 1000:
+        expired_names = [
+            name
+            for name, (cached_at, _, _) in _TG_PACK_CACHE.items()
+            if now - cached_at >= _TG_PACK_CACHE_TTL
+        ]
+        for name in expired_names:
+            _TG_PACK_CACHE.pop(name, None)
+
+    if len(_TG_PACK_CACHE) > 1000:
+        removable_entries = sorted(
+            (cached_at, name)
+            for name, (cached_at, _, _) in _TG_PACK_CACHE.items()
+            if name not in pack_names
+        )
+        for _, name in removable_entries[:len(_TG_PACK_CACHE) - 1000]:
+            _TG_PACK_CACHE.pop(name, None)
+
     # ⚡ Bolt Optimization: Concurrently validate packs with bounded concurrency (Semaphore=5)
     # Impact: Reduces N sequential network calls to Telegram down to O(N/5) while preventing HTTP 429 rate limit drops that could lead to accidental pack deletion
     sem = asyncio.Semaphore(5)
 
     async def _validate_single_pack(name, title):
         now = time.time()
-
-        # Prevent memory leaks
-        if len(_TG_PACK_CACHE) > 1000:
-            _TG_PACK_CACHE.clear()
 
         # ⚡ Bolt Optimization: Cache expensive Telegram API calls per pack for 5 minutes
         # Impact: Drastically reduces network latency and avoids 429 errors when reloading bot menus (e.g. Grimoire)

--- a/tests/test_main_forge_handlers.py
+++ b/tests/test_main_forge_handlers.py
@@ -65,7 +65,10 @@ def _patch_heavy_imports():
     telegram_ext.filters = MagicMock()
 
     # telegram.error module
-    telegram_error.BadRequest = Exception
+    class BadRequest(Exception):
+        pass
+
+    telegram_error.BadRequest = BadRequest
 
     stubs = {
         "telegram": telegram,
@@ -666,17 +669,53 @@ class TestCreateSticker(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class TestValidateAndSyncPacks(unittest.TestCase):
+    def setUp(self):
+        _main_mod._TG_PACK_CACHE.clear()
+
     @patch("main.get_user_packs")
     @patch("main.delete_pack_from_db")
-    def test_exception_handling_deletes_pack(self, mock_delete, mock_get_packs):
+    def test_bad_request_deletes_pack(self, mock_delete, mock_get_packs):
         mock_get_packs.return_value = [("pack_name", "Pack Title")]
         bot = AsyncMock()
-        bot.get_sticker_set.side_effect = Exception("Not found")
+        bot.get_sticker_set.side_effect = _main_mod.BadRequest("Not found")
 
         valid = _run(validate_and_sync_packs(bot, 123))
 
         mock_delete.assert_called_once_with(123, "pack_name")
         self.assertEqual(valid, [])
+
+    @patch("main.get_user_packs")
+    @patch("main.delete_pack_from_db")
+    def test_transient_exception_does_not_delete_or_cache_pack(self, mock_delete, mock_get_packs):
+        mock_get_packs.return_value = [("pack_name", "Pack Title")]
+        bot = AsyncMock()
+        bot.get_sticker_set.side_effect = TimeoutError("temporary timeout")
+
+        valid = _run(validate_and_sync_packs(bot, 123))
+
+        mock_delete.assert_not_called()
+        self.assertEqual(valid, [])
+        self.assertNotIn("pack_name", _main_mod._TG_PACK_CACHE)
+
+    @patch("main.get_user_packs")
+    @patch("main.delete_pack_from_db")
+    def test_transient_exception_for_one_user_does_not_skip_next_api_call(self, mock_delete, mock_get_packs):
+        mock_get_packs.return_value = [("pack_name", "Pack Title")]
+        bot = AsyncMock()
+        recovered_sticker_set = MagicMock()
+        recovered_sticker_set.title = "Pack Title"
+        bot.get_sticker_set.side_effect = [
+            TimeoutError("temporary timeout"),
+            recovered_sticker_set,
+        ]
+
+        first_valid = _run(validate_and_sync_packs(bot, 123))
+        second_valid = _run(validate_and_sync_packs(bot, 456))
+
+        mock_delete.assert_not_called()
+        self.assertEqual(first_valid, [])
+        self.assertEqual(second_valid, [("pack_name", "Pack Title")])
+        self.assertEqual(bot.get_sticker_set.await_count, 2)
 
     @patch("main.get_user_packs")
     @patch("main.update_pack_title_in_db")

--- a/tests/test_main_forge_handlers.py
+++ b/tests/test_main_forge_handlers.py
@@ -717,6 +717,33 @@ class TestValidateAndSyncPacks(unittest.TestCase):
         self.assertEqual(second_valid, [("pack_name", "Pack Title")])
         self.assertEqual(bot.get_sticker_set.await_count, 2)
 
+    @patch("main.time.time")
+    @patch("main.get_user_packs")
+    def test_cache_eviction_preserves_fresh_entries_for_same_batch(self, mock_get_packs, mock_time):
+        mock_time.return_value = 1000.0
+        mock_get_packs.return_value = [
+            ("uncached_pack", "Uncached Pack"),
+            ("cached_pack_b", "Cached Pack B"),
+            ("cached_pack_c", "Cached Pack C"),
+        ]
+        for i in range(1001):
+            _main_mod._TG_PACK_CACHE[f"expired_pack_{i}"] = (0.0, "Expired Pack", "valid")
+        _main_mod._TG_PACK_CACHE["cached_pack_b"] = (999.0, "Cached Pack B", "valid")
+        _main_mod._TG_PACK_CACHE["cached_pack_c"] = (999.0, "Cached Pack C", "valid")
+        bot = AsyncMock()
+        uncached_sticker_set = MagicMock()
+        uncached_sticker_set.title = "Uncached Pack"
+        bot.get_sticker_set.return_value = uncached_sticker_set
+
+        valid = _run(validate_and_sync_packs(bot, 123))
+
+        bot.get_sticker_set.assert_awaited_once_with("uncached_pack")
+        self.assertEqual(valid, [
+            ("uncached_pack", "Uncached Pack"),
+            ("cached_pack_b", "Cached Pack B"),
+            ("cached_pack_c", "Cached Pack C"),
+        ])
+
     @patch("main.get_user_packs")
     @patch("main.update_pack_title_in_db")
     def test_syncs_title_and_returns_valid(self, mock_update, mock_get_packs):


### PR DESCRIPTION
💡 What: Added an in-memory TTL cache (`_TG_PACK_CACHE`) in `main.py` for Telegram `get_sticker_set` network requests during pack validation and syncing.
🎯 Why: `validate_and_sync_packs` was executing N+1 network requests directly to Telegram's API for every pack a user had, every time they navigated through certain bot menus (e.g. their Grimoire). This led to significant performance degradation and frequent 429 rate limits, which could trigger accidental pack deletions in fallback blocks. 
📊 Impact: Reduces sequential network calls and latency down to near zero on repeated menu loads, avoiding O(N) external requests per navigation.
🔬 Measurement: Verify by executing bot flows with multiple packs attached to a user—the initial load takes standard API time, while subsequent navigations load instantly via cache without querying the Telegram API.

---
*PR created automatically by Jules for task [6448755275013650241](https://jules.google.com/task/6448755275013650241) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pack validation/pruning paths and introduces shared in-memory caching/eviction, which could affect data consistency or stale results if edge cases aren’t covered, though changes are localized and tested.
> 
> **Overview**
> `validate_and_sync_packs` now uses an in-memory 5‑minute TTL cache for Telegram `get_sticker_set` lookups, with size/TTL-based eviction to cap memory growth and reduce repeated network calls.
> 
> Pack pruning logic is tightened: only `BadRequest` responses mark a pack as deleted and trigger DB removal, while other exceptions are treated as transient (`unknown`) and logged without deleting or caching results. Tests are updated/expanded to cover the new `BadRequest` behavior, transient error handling, and cache eviction semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64b71ffd1ec5320e520de2ebcb6b5beb17a64947. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Implemented caching for Telegram sticker set validation results to reduce redundant API calls and improve response times.

* **Bug Fixes**
  * Enhanced error handling to correctly distinguish between deleted sticker sets and transient failures.
  * Fixed database pruning logic to only remove packs marked as deleted, improving data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->