### PR TITLE
⚡ Bolt: Use executemany for batched SQLite operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -30,3 +30,6 @@
 ## 2024-05-22 - Optimizing Directory Traversal with os.scandir()
 **Learning:** In `pipeline/exporters/png_sequence_exporter.py`, aggregating the file sizes of exported PNG sequences used `os.listdir()` paired with repeated `os.path.getsize()` calls inside a list comprehension. This approach triggered multiple system calls for file metadata.
 **Action:** Replaced `os.listdir()` and `os.path.getsize()` with `os.scandir()`, which yields file attributes (like size) during the initial directory traversal. This minimizes redundant system calls and provides a measurable performance improvement (up to ~23% speedup) when processing directories containing numerous files.
+## 2024-05-23 - Batching SQLite Operations
+**Learning:** Found that modifying the database sequentially inside a loop (e.g. `c.execute("UPDATE ...")` inside a `for` loop) causes O(N) database round-trips, significantly degrading performance.
+**Action:** Accumulate database arguments inside the loop and use a single `c.executemany("UPDATE ...", data)` call afterwards. This reduces the database round-trips to O(1) and leverages SQLite's prepared statement reuse for much better performance.

--- a/api.py
+++ b/api.py
@@ -350,17 +350,24 @@ async def _validate_packs_async(token, user_id):
         results = await asyncio.gather(*tasks)
 
         valid = []
+        updates = []
+        deletes = []
         for res in results:
             name, title, old_title, status = res["name"], res["title"], res["old_title"], res["status"]
             if status == "valid":
                 if title != old_title:
-                    c.execute(
-                        "UPDATE packs SET title = ? WHERE user_id = ? AND name = ?",
-                        (title, user_id, name)
-                    )
+                    updates.append((title, user_id, name))
                 valid.append({"name": name, "title": title, "link": f"https://t.me/addstickers/{name}"})
             else:
-                c.execute("DELETE FROM packs WHERE user_id = ? AND name = ?", (user_id, name))
+                deletes.append((user_id, name))
+
+        # ⚡ Bolt Optimization: Batch multiple database updates/deletes into single executemany calls
+        # Impact: Reduces database round-trips from O(N) to O(1) for loops modifying the database
+        if updates:
+            c.executemany("UPDATE packs SET title = ? WHERE user_id = ? AND name = ?", updates)
+        if deletes:
+            c.executemany("DELETE FROM packs WHERE user_id = ? AND name = ?", deletes)
+
         conn.commit()
         conn.close()
         return valid

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -669,16 +669,14 @@ class TestValidatePacksAsync(unittest.TestCase):
             from api import _validate_packs_async
             _run_async(_validate_packs_async("fake:token", 42))
 
-        # cursor.execute should have been called for SELECT + UPDATE
-        calls = cursor.execute.call_args_list
+        calls = cursor.executemany.call_args_list
         update_calls = [c for c in calls if "UPDATE" in str(c)]
         self.assertEqual(len(update_calls), 1)
-        # The UPDATE must carry the new title and correct user_id / name
         update_args = update_calls[0][0]
         self.assertIn("UPDATE packs SET title", update_args[0])
-        self.assertEqual(update_args[1][0], "New Title")
-        self.assertEqual(update_args[1][1], 42)
-        self.assertEqual(update_args[1][2], "mypack")
+        self.assertEqual(update_args[1][0][0], "New Title")
+        self.assertEqual(update_args[1][0][1], 42)
+        self.assertEqual(update_args[1][0][2], "mypack")
 
     def test_title_update_commits_on_existing_connection(self):
         """conn.commit() must be called for a title change (not a new connection)."""
@@ -717,13 +715,13 @@ class TestValidatePacksAsync(unittest.TestCase):
             from api import _validate_packs_async
             _run_async(_validate_packs_async("fake:token", 7))
 
-        calls = cursor.execute.call_args_list
+        calls = cursor.executemany.call_args_list
         delete_calls = [c for c in calls if "DELETE" in str(c)]
         self.assertEqual(len(delete_calls), 1)
         delete_args = delete_calls[0][0]
         self.assertIn("DELETE FROM packs", delete_args[0])
-        self.assertEqual(delete_args[1][0], 7)   # user_id
-        self.assertEqual(delete_args[1][1], "deadpack")
+        self.assertEqual(delete_args[1][0][0], 7)   # user_id
+        self.assertEqual(delete_args[1][0][1], "deadpack")
 
     def test_missing_pack_commits_delete_on_existing_connection(self):
         row = _make_db_row("deadpack", "Dead Pack")


### PR DESCRIPTION
💡 What: The optimization replaces individual `c.execute()` calls inside a loop with accumulated lists and a single `c.executemany()` call.
🎯 Why: Iterating over packs and executing an `UPDATE` or `DELETE` sequentially causes O(N) database round-trips. This becomes a major bottleneck for users with many packs or when bulk synchronizing with Telegram.
📊 Impact: Reduces database round-trips from O(N) to O(1).
🔬 Measurement: Run `tests/test_api_helpers.py` to verify that `executemany` handles the database updates and deletes correctly. Tests pass successfully.

---
*PR created automatically by Jules for task [3822754928998788899](https://jules.google.com/task/3822754928998788899) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how `packs` rows are updated/deleted during Telegram validation; batching could mask per-row failures or change transaction behavior, but the SQL statements and commit semantics are otherwise unchanged.
> 
> **Overview**
> **Optimizes miniapp pack validation DB writes** by accumulating title updates and deletions during `_validate_packs_async` and applying them via batched `cursor.executemany()` calls instead of per-pack `cursor.execute()` inside the loop.
> 
> Updates tests to assert `executemany` is used and to validate the new argument structure for the batched `UPDATE`/`DELETE` operations, and documents the batching optimization in `.jules/bolt.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c074bfe38d88c7cbeb07586213a31d4c21930c42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->