### PR TITLE
⚡ Bolt: Batch database updates with executemany

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -30,3 +30,6 @@
 ## 2024-05-22 - Optimizing Directory Traversal with os.scandir()
 **Learning:** In `pipeline/exporters/png_sequence_exporter.py`, aggregating the file sizes of exported PNG sequences used `os.listdir()` paired with repeated `os.path.getsize()` calls inside a list comprehension. This approach triggered multiple system calls for file metadata.
 **Action:** Replaced `os.listdir()` and `os.path.getsize()` with `os.scandir()`, which yields file attributes (like size) during the initial directory traversal. This minimizes redundant system calls and provides a measurable performance improvement (up to ~23% speedup) when processing directories containing numerous files.
+## 2024-05-23 - Batching database updates with executemany()
+**Learning:** Found that `api._validate_packs_async` was executing separate `UPDATE` and `DELETE` queries within a loop, one per pack. This can lead to N round-trips to the database when a user has multiple updated or invalid packs.
+**Action:** Replaced the individual `c.execute()` calls within the loop with two `c.executemany()` calls outside the loop by batching arguments into `updates` and `deletes` lists. This changes the O(N) database executions to O(1) batched operations.

--- a/api.py
+++ b/api.py
@@ -350,17 +350,24 @@ async def _validate_packs_async(token, user_id):
         results = await asyncio.gather(*tasks)
 
         valid = []
+        updates = []
+        deletes = []
         for res in results:
             name, title, old_title, status = res["name"], res["title"], res["old_title"], res["status"]
             if status == "valid":
                 if title != old_title:
-                    c.execute(
-                        "UPDATE packs SET title = ? WHERE user_id = ? AND name = ?",
-                        (title, user_id, name)
-                    )
+                    updates.append((title, user_id, name))
                 valid.append({"name": name, "title": title, "link": f"https://t.me/addstickers/{name}"})
             else:
-                c.execute("DELETE FROM packs WHERE user_id = ? AND name = ?", (user_id, name))
+                deletes.append((user_id, name))
+
+        # ⚡ Bolt Optimization: Batch database operations to minimize SQLite round-trips
+        # Impact: Improves performance from O(N) database calls to O(1) batched executemany calls for users with many packs needing updates
+        if updates:
+            c.executemany("UPDATE packs SET title = ? WHERE user_id = ? AND name = ?", updates)
+        if deletes:
+            c.executemany("DELETE FROM packs WHERE user_id = ? AND name = ?", deletes)
+
         conn.commit()
         conn.close()
         return valid

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -669,16 +669,16 @@ class TestValidatePacksAsync(unittest.TestCase):
             from api import _validate_packs_async
             _run_async(_validate_packs_async("fake:token", 42))
 
-        # cursor.execute should have been called for SELECT + UPDATE
-        calls = cursor.execute.call_args_list
+        # cursor.executemany should have been called for UPDATE
+        calls = cursor.executemany.call_args_list
         update_calls = [c for c in calls if "UPDATE" in str(c)]
         self.assertEqual(len(update_calls), 1)
         # The UPDATE must carry the new title and correct user_id / name
         update_args = update_calls[0][0]
         self.assertIn("UPDATE packs SET title", update_args[0])
-        self.assertEqual(update_args[1][0], "New Title")
-        self.assertEqual(update_args[1][1], 42)
-        self.assertEqual(update_args[1][2], "mypack")
+        self.assertEqual(update_args[1][0][0], "New Title")
+        self.assertEqual(update_args[1][0][1], 42)
+        self.assertEqual(update_args[1][0][2], "mypack")
 
     def test_title_update_commits_on_existing_connection(self):
         """conn.commit() must be called for a title change (not a new connection)."""
@@ -717,13 +717,13 @@ class TestValidatePacksAsync(unittest.TestCase):
             from api import _validate_packs_async
             _run_async(_validate_packs_async("fake:token", 7))
 
-        calls = cursor.execute.call_args_list
+        calls = cursor.executemany.call_args_list
         delete_calls = [c for c in calls if "DELETE" in str(c)]
         self.assertEqual(len(delete_calls), 1)
         delete_args = delete_calls[0][0]
         self.assertIn("DELETE FROM packs", delete_args[0])
-        self.assertEqual(delete_args[1][0], 7)   # user_id
-        self.assertEqual(delete_args[1][1], "deadpack")
+        self.assertEqual(delete_args[1][0][0], 7)   # user_id
+        self.assertEqual(delete_args[1][0][1], "deadpack")
 
     def test_missing_pack_commits_delete_on_existing_connection(self):
         row = _make_db_row("deadpack", "Dead Pack")


### PR DESCRIPTION
💡 **What:** 
Refactored `api._validate_packs_async` to use `c.executemany()` instead of `c.execute()` inside the pack validation loop. Gathered update and delete arguments into separate lists and executed them via batched queries.

🎯 **Why:** 
Previously, `UPDATE` and `DELETE` queries for syncing pack titles and removing invalid packs were executed individually in a loop (`c.execute`). For users with many packs needing updates, this caused an N+1 query performance bottleneck by executing `N` separate database queries and triggering `N` roundtrips.

📊 **Impact:** 
Improves performance by reducing SQLite round-trips from O(N) database calls to O(1) batched `executemany` calls when a user has multiple updated or invalid packs.

🔬 **Measurement:** 
Run `TELEGRAM_BOT_TOKEN=dummy STIXMAGIC_API_KEY=supersecret poetry run python -m unittest tests/test_api_helpers.py` and verify all tests pass without regressions, ensuring that the batched commands correctly execute the data mutations.

---
*PR created automatically by Jules for task [4821339055062990609](https://jules.google.com/task/4821339055062990609) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes write paths in `api._validate_packs_async` by batching `UPDATE`/`DELETE` operations, which could affect pack synchronization correctness if argument collection/order is wrong. Covered by updated unit tests, but it still touches production data mutation logic.
> 
> **Overview**
> Improves `/api/miniapp/packs` validation performance by collecting pack title changes and stale-pack removals during Telegram validation and applying them via two batched SQLite `executemany()` calls instead of per-pack `execute()` calls.
> 
> Updates unit tests to assert `executemany()` usage and correct batched parameter shapes, and documents the optimization in `.jules/bolt.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4164637548d74fbd9dddffdc8763cfcbded8303a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->