### PR TITLE
🧹 Remove unused future annotations import from pipeline manifest

### DIFF
--- a/pipeline/manifest.py
+++ b/pipeline/manifest.py
@@ -56,8 +56,6 @@ The generated JSON has the following top-level structure::
     }
 """
 
-from __future__ import annotations
-
 import json
 import logging
 import os


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` line from `pipeline/manifest.py`.
💡 **Why:** `from __future__ import annotations` was unnecessarily imported as it wasn't leveraged for the type checking (Python 3.12 doesn't require it implicitly here or no lazy types were used). This cleans up unused imports and improves code readability and maintainability.
✅ **Verification:** Verified by checking syntax over `pipeline/manifest.py` and making sure that all tests keep failing properly as before due to the environment problems but no new errors related to the pipeline manifest were introduced.
✨ **Result:** A cleaner codebase with fewer redundant imports.

---
*PR created automatically by Jules for task [10699344044572455783](https://jules.google.com/task/10699344044572455783) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup that only removes an unused `__future__` import; runtime behavior and manifest generation logic are unchanged.
> 
> **Overview**
> Removes the unused `from __future__ import annotations` line from `pipeline/manifest.py` to clean up imports with no functional changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6164cc033e23bbd0788e1323440e1d14178cc46e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->