### PR TITLE
🧪 Add unit tests for pipeline asset model

### DIFF
--- a/tests/test_asset_model.py
+++ b/tests/test_asset_model.py
@@ -1,0 +1,163 @@
+import unittest
+from pipeline.asset_model import Asset, AssetCategory, SourceFormat, AssetTheme
+
+class TestAssetModel(unittest.TestCase):
+    def test_basic_instantiation(self):
+        asset = Asset(
+            id="letter_a",
+            name="Letter A",
+            category=AssetCategory.LETTER,
+            source_format=SourceFormat.PNG,
+            source_path="assets/source/letter_a.png"
+        )
+        self.assertEqual(asset.id, "letter_a")
+        self.assertEqual(asset.name, "Letter A")
+        self.assertEqual(asset.category, AssetCategory.LETTER)
+        self.assertEqual(asset.source_format, SourceFormat.PNG)
+        self.assertEqual(asset.source_path, "assets/source/letter_a.png")
+        self.assertEqual(asset.width, 512)
+        self.assertEqual(asset.height, 512)
+        self.assertEqual(asset.transparent_background, True)
+        self.assertEqual(asset.theme, None)
+        self.assertEqual(asset.tags, [])
+        self.assertEqual(asset.animation_compatible_presets, [])
+        self.assertEqual(asset.export_targets, [])
+        self.assertEqual(asset.notes, "")
+
+    def test_to_dict_all_fields(self):
+        asset = Asset(
+            id="symbol_cloud",
+            name="Cloud Symbol",
+            category=AssetCategory.SYMBOL,
+            source_format=SourceFormat.SVG,
+            source_path="assets/source/symbol_cloud.svg",
+            width=1024,
+            height=768,
+            transparent_background=False,
+            theme=AssetTheme.CLOUD,
+            tags=["weather", "fluffy"],
+            animation_compatible_presets=["float", "fade"],
+            export_targets=["png", "webp"],
+            notes="Use with care"
+        )
+        expected = {
+            "id": "symbol_cloud",
+            "name": "Cloud Symbol",
+            "category": "symbol",
+            "source_format": "svg",
+            "source_path": "assets/source/symbol_cloud.svg",
+            "width": 1024,
+            "height": 768,
+            "transparent_background": False,
+            "theme": "cloud",
+            "tags": ["weather", "fluffy"],
+            "animation_compatible_presets": ["float", "fade"],
+            "export_targets": ["png", "webp"],
+            "notes": "Use with care"
+        }
+        self.assertEqual(asset.to_dict(), expected)
+
+    def test_to_dict_missing_optional_fields(self):
+        asset = Asset(
+            id="letter_a",
+            name="Letter A",
+            category=AssetCategory.LETTER,
+            source_format=SourceFormat.PNG,
+            source_path="assets/source/letter_a.png"
+        )
+        data = asset.to_dict()
+        self.assertEqual(data["theme"], None)
+        self.assertEqual(data["tags"], [])
+        self.assertEqual(data["animation_compatible_presets"], [])
+        self.assertEqual(data["export_targets"], [])
+        self.assertEqual(data["notes"], "")
+        self.assertEqual(data["width"], 512)
+        self.assertEqual(data["height"], 512)
+        self.assertEqual(data["transparent_background"], True)
+
+    def test_from_dict_all_fields(self):
+        data = {
+            "id": "symbol_cloud",
+            "name": "Cloud Symbol",
+            "category": "symbol",
+            "source_format": "svg",
+            "source_path": "assets/source/symbol_cloud.svg",
+            "width": 1024,
+            "height": 768,
+            "transparent_background": False,
+            "theme": "cloud",
+            "tags": ["weather", "fluffy"],
+            "animation_compatible_presets": ["float", "fade"],
+            "export_targets": ["png", "webp"],
+            "notes": "Use with care"
+        }
+        asset = Asset.from_dict(data)
+        self.assertEqual(asset.id, "symbol_cloud")
+        self.assertEqual(asset.name, "Cloud Symbol")
+        self.assertEqual(asset.category, AssetCategory.SYMBOL)
+        self.assertEqual(asset.source_format, SourceFormat.SVG)
+        self.assertEqual(asset.source_path, "assets/source/symbol_cloud.svg")
+        self.assertEqual(asset.width, 1024)
+        self.assertEqual(asset.height, 768)
+        self.assertEqual(asset.transparent_background, False)
+        self.assertEqual(asset.theme, AssetTheme.CLOUD)
+        self.assertEqual(asset.tags, ["weather", "fluffy"])
+        self.assertEqual(asset.animation_compatible_presets, ["float", "fade"])
+        self.assertEqual(asset.export_targets, ["png", "webp"])
+        self.assertEqual(asset.notes, "Use with care")
+
+    def test_from_dict_missing_optional_fields(self):
+        data = {
+            "id": "letter_a",
+            "name": "Letter A",
+            "category": "letter",
+            "source_format": "png",
+            "source_path": "assets/source/letter_a.png"
+        }
+        asset = Asset.from_dict(data)
+        self.assertEqual(asset.id, "letter_a")
+        self.assertEqual(asset.theme, None)
+        self.assertEqual(asset.tags, [])
+        self.assertEqual(asset.animation_compatible_presets, [])
+        self.assertEqual(asset.export_targets, [])
+        self.assertEqual(asset.notes, "")
+        self.assertEqual(asset.width, 512)
+        self.assertEqual(asset.height, 512)
+        self.assertEqual(asset.transparent_background, True)
+
+    def test_from_dict_invalid_category(self):
+        data = {
+            "id": "bad_asset",
+            "name": "Bad Asset",
+            "category": "invalid_category",
+            "source_format": "png",
+            "source_path": "assets/source/bad.png"
+        }
+        with self.assertRaises(ValueError):
+            Asset.from_dict(data)
+
+    def test_from_dict_invalid_source_format(self):
+        data = {
+            "id": "bad_asset",
+            "name": "Bad Asset",
+            "category": "letter",
+            "source_format": "invalid_format",
+            "source_path": "assets/source/bad.png"
+        }
+        with self.assertRaises(ValueError):
+            Asset.from_dict(data)
+
+    def test_from_dict_invalid_theme(self):
+        data = {
+            "id": "bad_asset",
+            "name": "Bad Asset",
+            "category": "letter",
+            "source_format": "png",
+            "source_path": "assets/source/bad.png",
+            "theme": "invalid_theme"
+        }
+        with self.assertRaises(ValueError):
+            Asset.from_dict(data)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** 
Added unit tests for the `Asset` dataclass in `pipeline/asset_model/__init__.py`. Specifically focuses on verifying the correctness of `from_dict` and `to_dict` serialization/deserialization methods which parse raw dictionaries into strictly-typed dataclasses.

📊 **Coverage:**
The new `test_asset_model.py` test file now covers:
* Basic instantiation of the `Asset` dataclass and proper default assignment.
* Serialization via `to_dict` correctly handling populated options and missing optional items like `theme` or `tags`.
* Deserialization via `from_dict` parsing valid definitions flawlessly.
* Validation during `from_dict` appropriately bubbling up `ValueError` when encountering invalid Enumeration types like an invalid `category`, `source_format`, or `theme`.

✨ **Result:**
The `Asset` dataclass (and its serialization logic), which forms the core visual data model of the pipeline, is now fully backed by automated tests, preventing potential schema breakages or type drift.

---
*PR created automatically by Jules for task [2370273364030193884](https://jules.google.com/task/2370273364030193884) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds test coverage only, with no production code changes; failures would only affect CI/test runs.
> 
> **Overview**
> Adds `tests/test_asset_model.py` to exercise the `pipeline.asset_model.Asset` dataclass.
> 
> Covers default field values, full and minimal `to_dict`/`from_dict` serialization/deserialization, and asserts `ValueError` is raised for invalid `category`, `source_format`, and `theme` inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbde33a4f47303f799094bddb8349a35f745092c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->