### PR TITLE
🧹 fix(tests): remove unused call import in test_api_helpers.py

### DIFF
--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -20,7 +20,7 @@ import sys
 import time
 import tempfile
 import unittest
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import urlencode
 
 


### PR DESCRIPTION
🎯 What: Removed the unused `call` import from `unittest.mock` in `tests/test_api_helpers.py`.
💡 Why: Improves code health, maintainability, and readability by keeping the test file namespace clean and avoiding confusion about what is being used in the tests.
✅ Verification: Ran the test suite specifically for `tests/test_api_helpers.py` and they all passed. There are no side-effects from removing this unused mock element.
✨ Result: Cleaner imports in `test_api_helpers.py`.

---
*PR created automatically by Jules for task [7277585213738721261](https://jules.google.com/task/7277585213738721261) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes an unused test-only import with no behavioral changes.
> 
> **Overview**
> Removes the unused `call` symbol from the `unittest.mock` import list in `tests/test_api_helpers.py` to keep the test namespace clean.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49e9b5765de029c90bc0694161a4d5bee6ef788c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->