### PR TITLE
🧹 [code health improvement] Remove unused validate_init_data import from stixmagic/__init__.py

### DIFF
--- a/stixmagic/__init__.py
+++ b/stixmagic/__init__.py
@@ -15,4 +15,3 @@ from .contracts import (  # noqa: F401
     START_PAYLOAD_MANAGE,
 )
 from .settings import AppSettings, get_settings  # noqa: F401
-from .telegram_auth import TelegramInitDataError, validate_init_data  # noqa: F401


### PR DESCRIPTION
🎯 What: Removed unused TelegramInitDataError and validate_init_data imports from stixmagic/__init__.py.
💡 Why: stixmagic/__init__.py was exporting TelegramInitDataError and validate_init_data but nothing relies on them being exported from there, reducing namespace clutter.
✅ Verification: Ran test suite to ensure the imports were not used anywhere through stixmagic namespace. The same pre-existing test failures occurred before and after.
✨ Result: Cleaned up stixmagic/__init__.py imports.

---
*PR created automatically by Jules for task [1955359823397987216](https://jules.google.com/task/1955359823397987216) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only stops re-exporting unused symbols and does not change runtime behavior unless external code imported them from `stixmagic`.
> 
> **Overview**
> Removes the `TelegramInitDataError` and `validate_init_data` imports from `stixmagic/__init__.py`, reducing the public `stixmagic` namespace surface area.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51b1ee13e7f27932f37580fc08e87a3301943621. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->