### PR TITLE
🧪 Add tests for MotionPreset in preset.py

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,7 +1,11 @@
-Title: 🧪 Test validate_pack_title failure in create_title
+🎯 **What:**
+The testing gap addressed is the missing unit test file for `pipeline/motion_presets/preset.py`. The `MotionPreset` data class contains pure logic functions (`is_recommended_for`, `to_dict`, `from_dict`) that are easy to test in isolation but were entirely lacking coverage.
 
-🎯 **What:** The `create_title` handler in `main.py` lacked a unit test verifying its behaviour when a pack title validation failed.
+📊 **Coverage:**
+The new test suite `tests/test_pipeline_preset.py` covers:
+- Happy paths: Initializing defaults, parsing full dictionary data, serialization, and correct category evaluations.
+- Edge Cases: Parsing dictionaries with missing optional fields, and handling empty recommended category lists.
+- Other methods: `__repr__` output correctness.
 
-📊 **Coverage:** A new test case `test_mocked_validate_pack_title_false` was added to `tests/test_main_forge_handlers.py`. It uses a mock to ensure that a title validation returning `False` correctly causes the handler to prompt the user again by returning the `WAITING_TITLE` state and sending the appropriate error message via Telegram.
-
-✨ **Result:** Enhanced test coverage for edge cases involving pack title validation during the pack creation flow.
+✨ **Result:**
+Increased code reliability and coverage for the core `MotionPreset` pipeline model, providing a robust safety net for any future refactoring of how presets handle their configuration and schemas.

--- a/tests/test_pipeline_preset.py
+++ b/tests/test_pipeline_preset.py
@@ -1,0 +1,102 @@
+import unittest
+from pipeline.motion_presets.preset import MotionPreset
+
+class TestMotionPreset(unittest.TestCase):
+    def test_default_values(self):
+        preset = MotionPreset(id="test_id", name="Test Name")
+        self.assertEqual(preset.id, "test_id")
+        self.assertEqual(preset.name, "Test Name")
+        self.assertTrue(preset.loopable)
+        self.assertEqual(preset.duration_ms, 1000)
+        self.assertTrue(preset.alpha_safe)
+        self.assertTrue(preset.overlay_safe)
+        self.assertTrue(preset.sticker_safe)
+        self.assertEqual(preset.recommended_categories, [])
+        self.assertEqual(preset.parameter_schema, {})
+        self.assertEqual(preset.description, "")
+
+    def test_is_recommended_for_empty_list(self):
+        preset = MotionPreset(id="test_id", name="Test Name")
+        self.assertTrue(preset.is_recommended_for("any_category"))
+
+    def test_is_recommended_for_specific_category(self):
+        preset = MotionPreset(id="test_id", name="Test Name", recommended_categories=["cat1", "cat2"])
+        self.assertTrue(preset.is_recommended_for("cat1"))
+        self.assertTrue(preset.is_recommended_for("cat2"))
+        self.assertFalse(preset.is_recommended_for("cat3"))
+
+    def test_to_dict(self):
+        preset = MotionPreset(
+            id="test_id",
+            name="Test Name",
+            loopable=False,
+            duration_ms=2000,
+            alpha_safe=False,
+            overlay_safe=False,
+            sticker_safe=False,
+            recommended_categories=["cat1"],
+            parameter_schema={"param1": "value1"},
+            description="Test description"
+        )
+        expected_dict = {
+            "id": "test_id",
+            "name": "Test Name",
+            "loopable": False,
+            "duration_ms": 2000,
+            "alpha_safe": False,
+            "overlay_safe": False,
+            "sticker_safe": False,
+            "recommended_categories": ["cat1"],
+            "parameter_schema": {"param1": "value1"},
+            "description": "Test description"
+        }
+        self.assertEqual(preset.to_dict(), expected_dict)
+
+    def test_from_dict(self):
+        data = {
+            "id": "test_id",
+            "name": "Test Name",
+            "loopable": False,
+            "duration_ms": 2000,
+            "alpha_safe": False,
+            "overlay_safe": False,
+            "sticker_safe": False,
+            "recommended_categories": ["cat1"],
+            "parameter_schema": {"param1": "value1"},
+            "description": "Test description"
+        }
+        preset = MotionPreset.from_dict(data)
+        self.assertEqual(preset.id, "test_id")
+        self.assertEqual(preset.name, "Test Name")
+        self.assertFalse(preset.loopable)
+        self.assertEqual(preset.duration_ms, 2000)
+        self.assertFalse(preset.alpha_safe)
+        self.assertFalse(preset.overlay_safe)
+        self.assertFalse(preset.sticker_safe)
+        self.assertEqual(preset.recommended_categories, ["cat1"])
+        self.assertEqual(preset.parameter_schema, {"param1": "value1"})
+        self.assertEqual(preset.description, "Test description")
+
+    def test_from_dict_with_missing_optional_fields(self):
+        data = {
+            "id": "test_id",
+            "name": "Test Name"
+        }
+        preset = MotionPreset.from_dict(data)
+        self.assertEqual(preset.id, "test_id")
+        self.assertEqual(preset.name, "Test Name")
+        self.assertTrue(preset.loopable)
+        self.assertEqual(preset.duration_ms, 1000)
+        self.assertTrue(preset.alpha_safe)
+        self.assertTrue(preset.overlay_safe)
+        self.assertTrue(preset.sticker_safe)
+        self.assertEqual(preset.recommended_categories, [])
+        self.assertEqual(preset.parameter_schema, {})
+        self.assertEqual(preset.description, "")
+
+    def test_repr(self):
+        preset = MotionPreset(id="test_id", name="Test Name", duration_ms=1500, loopable=False)
+        self.assertEqual(repr(preset), "<MotionPreset id='test_id' duration_ms=1500 loopable=False>")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** 
The testing gap addressed is the missing unit test file for `pipeline/motion_presets/preset.py`. The `MotionPreset` data class contains pure logic functions (`is_recommended_for`, `to_dict`, `from_dict`) that are easy to test in isolation but were entirely lacking coverage. 

📊 **Coverage:** 
The new test suite `tests/test_pipeline_preset.py` covers:
- Happy paths: Initializing defaults, parsing full dictionary data, serialization, and correct category evaluations.
- Edge Cases: Parsing dictionaries with missing optional fields, and handling empty recommended category lists.
- Other methods: `__repr__` output correctness.

✨ **Result:** 
Increased code reliability and coverage for the core `MotionPreset` pipeline model, providing a robust safety net for any future refactoring of how presets handle their configuration and schemas.

---
*PR created automatically by Jules for task [1756290810989874588](https://jules.google.com/task/1756290810989874588) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new unit test suite for `MotionPreset` without changing runtime behavior; risk is low aside from potential brittle assertions around `__repr__` formatting.
> 
> **Overview**
> Adds a new `tests/test_pipeline_preset.py` suite that exercises `MotionPreset`’s default field values, `is_recommended_for` behavior (including empty `recommended_categories`), `to_dict`/`from_dict` round-trips (including missing optional fields), and `__repr__` output.
> 
> Updates `pr_description.md` to describe the new coverage and expected reliability improvements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73b4e152602ba6169379231a44ea5329d708d8f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->