### PR TITLE
🧪 Add unit tests for GifExporter

### DIFF
--- a/tests/test_gif_exporter.py
+++ b/tests/test_gif_exporter.py
@@ -1,0 +1,63 @@
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from pipeline.asset_model.asset import Asset
+from pipeline.motion_presets.preset import MotionPreset
+from pipeline.exporters.gif_exporter import GifExporter
+
+
+class TestGifExporter(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.exporter = GifExporter(renders_dir=self.temp_dir)
+        self.asset = Asset(
+            id="test_asset",
+            name="Test Asset",
+            category="letter",
+            theme="neon",
+            source_format="png",
+            source_path="test.png",
+            width=100,
+            height=100,
+        )
+        self.preset = MotionPreset(
+            id="test_preset",
+            name="Test Preset",
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_export_success(self):
+        result = self.exporter.export(self.asset, self.preset)
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.format, "gif")
+        self.assertIsNotNone(result.path)
+        self.assertTrue(os.path.exists(result.path))
+        self.assertTrue(result.path.startswith(self.temp_dir))
+        self.assertTrue(result.path.endswith("test_asset_test_preset.gif"))
+
+        with open(result.path, "rb") as f:
+            content = f.read()
+            self.assertTrue(content.startswith(b"GIF89a"))
+
+    @patch("pipeline.exporters.gif_exporter.GifExporter._render_frames")
+    def test_export_exception_handled(self, mock_render_frames):
+        mock_render_frames.side_effect = Exception("Rendering failed")
+
+        result = self.exporter.export(self.asset, self.preset)
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.format, "gif")
+        self.assertEqual(result.message, "Rendering failed")
+
+        expected_path = self.exporter.output_path(self.asset, self.preset)
+        self.assertFalse(os.path.exists(expected_path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gif_exporter.py
+++ b/tests/test_gif_exporter.py
@@ -38,7 +38,7 @@ class TestGifExporter(unittest.TestCase):
         self.assertEqual(result.format, "gif")
         self.assertIsNotNone(result.path)
         self.assertTrue(os.path.exists(result.path))
-        self.assertTrue(result.path.startswith(self.temp_dir))
+        self.assertTrue(result.path.startswith(os.path.realpath(self.temp_dir)))
         self.assertTrue(result.path.endswith("test_asset_test_preset.gif"))
 
         with open(result.path, "rb") as f:


### PR DESCRIPTION
🎯 **What:** Missing test coverage for `pipeline.exporters.gif_exporter.GifExporter`.
📊 **Coverage:** Added tests to ensure successful exports create valid dummy files correctly and exception handling prevents crashes while returning error structures safely.
✨ **Result:** `GifExporter`'s error-handling and generation logic is verified, covering its branch of the codebase.

---
*PR created automatically by Jules for task [10685354022117167052](https://jules.google.com/task/10685354022117167052) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds isolated unit tests only, exercising placeholder GIF file creation and error handling without changing production logic.
> 
> **Overview**
> Adds `tests/test_gif_exporter.py` to validate `GifExporter.export()` creates a GIF file in a temp `renders_dir` with the expected naming and a valid `GIF89a` header.
> 
> Also verifies failures are handled safely by mocking `GifExporter._render_frames` to raise, asserting an error `ExportResult` is returned and no output file is left behind.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f364212896d6ca3efbf4d722abf567635989a36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->