### PR TITLE
🧹 [code health] Remove unused shutil import from exporters pipeline

### DIFF
--- a/pipeline/exporters/__init__.py
+++ b/pipeline/exporters/__init__.py
@@ -47,7 +47,6 @@ from __future__ import annotations
 
 import logging
 import os
-import shutil
 from dataclasses import dataclass, field
 from typing import Optional
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `import shutil` from `pipeline/exporters/__init__.py`.
💡 **Why:** Improves code maintainability and readability by removing an unused import that is no longer needed.
✅ **Verification:** Ran the full test suite and checked that no functionality was broken. Python can successfully load `pipeline.exporters`.
✨ **Result:** Cleaner imports in the exporters pipeline.

---
*PR created automatically by Jules for task [17386152725168717456](https://jules.google.com/task/17386152725168717456) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup: only removes an unused import with no behavioral impact.
> 
> **Overview**
> Removes the unused `shutil` import from `pipeline/exporters/__init__.py` to clean up module dependencies and satisfy linters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ecab8097935604df7307c1b86d297a954a99597. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->