### PR TITLE
🧪 Add tests for motion presets catalog

### DIFF
--- a/tests/test_motion_presets_catalog.py
+++ b/tests/test_motion_presets_catalog.py
@@ -1,0 +1,37 @@
+import unittest
+
+from pipeline.motion_presets.catalog import PRESETS, get_preset, list_presets
+from pipeline.motion_presets.preset import MotionPreset
+
+class TestMotionPresetsCatalog(unittest.TestCase):
+
+    def test_get_preset_existing(self):
+        """Test get_preset returns the correct preset for a valid ID."""
+        # Grab the first preset from the PRESETS dictionary
+        valid_id = list(PRESETS.keys())[0]
+        preset = get_preset(valid_id)
+        self.assertIsInstance(preset, MotionPreset)
+        self.assertEqual(preset.id, valid_id)
+        self.assertIs(preset, PRESETS[valid_id])
+
+    def test_get_preset_non_existing(self):
+        """Test get_preset raises KeyError for an invalid ID."""
+        with self.assertRaises(KeyError) as context:
+            get_preset("non_existent_preset_id_123")
+
+        self.assertIn("Unknown motion preset 'non_existent_preset_id_123'", str(context.exception))
+        self.assertIn("Available:", str(context.exception))
+
+    def test_list_presets(self):
+        """Test list_presets returns all presets as a list."""
+        presets_list = list_presets()
+        self.assertIsInstance(presets_list, list)
+        self.assertEqual(len(presets_list), len(PRESETS))
+
+        for preset in presets_list:
+            self.assertIsInstance(preset, MotionPreset)
+            self.assertIn(preset.id, PRESETS)
+            self.assertIs(preset, PRESETS[preset.id])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for `get_preset` and `list_presets` in `pipeline/motion_presets/catalog.py`.
📊 **Coverage:** The tests verify that `get_preset` correctly retrieves a preset by ID, correctly raises a `KeyError` for unknown IDs with the proper message, and that `list_presets` successfully returns all existing presets as a list.
✨ **Result:** Enhanced test coverage for the motion presets catalog logic, improving codebase reliability and safety for future refactoring.

---
*PR created automatically by Jules for task [5454136606711226699](https://jules.google.com/task/5454136606711226699) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds unit tests only; no production code changes. Low risk aside from potential brittleness if preset error messages or ordering change.
> 
> **Overview**
> Adds `tests/test_motion_presets_catalog.py` to validate the motion presets catalog helpers.
> 
> The tests assert that `get_preset` returns the exact registered `MotionPreset` instance for a valid id, raises `KeyError` with an informative message for unknown ids, and that `list_presets` returns all registered presets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02f46ad40615d0fce327d748bd77455f826ff3b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->