### PR TITLE
🧹 [code health] Remove unused shutil import

### DIFF
--- a/pipeline/exporters/__init__.py
+++ b/pipeline/exporters/__init__.py
@@ -47,7 +47,6 @@ from __future__ import annotations
 
 import logging
 import os
-import shutil
 from dataclasses import dataclass, field
 from typing import Optional
 


### PR DESCRIPTION
🎯 **What:** Removed unused `shutil` import in `pipeline/exporters/__init__.py`.
💡 **Why:** `shutil` is no longer used in this module, so removing it cleans up dead code and improves readability.
✅ **Verification:** Ran test suite with `TELEGRAM_BOT_TOKEN=dummy STIXMAGIC_API_KEY=supersecret poetry run python -m unittest discover tests` and confirmed no new failures were introduced.
✨ **Result:** Cleaned up unused import with zero risk of breaking functionality.

---
*PR created automatically by Jules for task [13042763211372191087](https://jules.google.com/task/13042763211372191087) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup that only removes an unused import and does not alter runtime behavior.
> 
> **Overview**
> Removes an unused `shutil` import from `pipeline/exporters/__init__.py`, reducing dead code without changing exporter behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0502cb34a762bcee91d32a2135f95cdbd45507a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->