### PR TITLE
🧹 Remove unused call import from test_api_helpers.py

### DIFF
--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -20,7 +20,7 @@ import sys
 import time
 import tempfile
 import unittest
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import urlencode
 
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `call` import from `tests/test_api_helpers.py`.
💡 **Why:** This improves the code health of the test file by removing an unused and confusing import, maintaining a clean state in the file and preventing confusion about what objects are being used.
✅ **Verification:** Verified by running the entire test suite via `TELEGRAM_BOT_TOKEN=dummy STIXMAGIC_API_KEY=supersecret poetry run python -m unittest tests/test_api_helpers.py`. All tests passed.
✨ **Result:** Cleaned up unused import while leaving all existing behavior and tests perfectly intact.

---
*PR created automatically by Jules for task [9385869001259869705](https://jules.google.com/task/9385869001259869705) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only cleanup removing an unused import with no behavior changes.
> 
> **Overview**
> Removes the unused `call` import from `tests/test_api_helpers.py` to reduce clutter and avoid implying it’s used in the test suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36c24cfa36059ad92d9fc742aedfbcee3cc034c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->