### PR TITLE
🧪 Add tests for pipeline/asset_model Asset serialization

### DIFF
--- a/tests/test_pipeline_asset_model.py
+++ b/tests/test_pipeline_asset_model.py
@@ -1,0 +1,161 @@
+"""
+Tests for pipeline/asset_model/__init__.py – Asset dataclass logic.
+
+Covers:
+ - Asset.to_dict() serialization
+ - Asset.from_dict() deserialization
+ - Default values handling
+ - Enum conversions
+"""
+
+import unittest
+from typing import Any
+
+from pipeline.asset_model import Asset, AssetCategory, AssetTheme, SourceFormat
+
+
+class TestAssetModel(unittest.TestCase):
+    def setUp(self):
+        self.mandatory_kwargs = {
+            "id": "letter_A",
+            "name": "Letter A",
+            "category": AssetCategory.LETTER,
+            "source_format": SourceFormat.PNG,
+            "source_path": "assets/source/letters/A.png"
+        }
+
+    def test_asset_to_dict_mandatory_only(self):
+        """Test serialization with only mandatory fields provided."""
+        asset = Asset(**self.mandatory_kwargs)
+
+        result = asset.to_dict()
+
+        expected = {
+            "id": "letter_A",
+            "name": "Letter A",
+            "category": "letter",
+            "source_format": "png",
+            "source_path": "assets/source/letters/A.png",
+            "width": 512,
+            "height": 512,
+            "transparent_background": True,
+            "theme": None,
+            "tags": [],
+            "animation_compatible_presets": [],
+            "export_targets": [],
+            "notes": ""
+        }
+        self.assertEqual(result, expected)
+
+    def test_asset_from_dict_mandatory_only(self):
+        """Test deserialization with only mandatory fields provided."""
+        data = {
+            "id": "letter_A",
+            "name": "Letter A",
+            "category": "letter",
+            "source_format": "png",
+            "source_path": "assets/source/letters/A.png"
+        }
+
+        asset = Asset.from_dict(data)
+
+        self.assertEqual(asset.id, "letter_A")
+        self.assertEqual(asset.name, "Letter A")
+        self.assertEqual(asset.category, AssetCategory.LETTER)
+        self.assertEqual(asset.source_format, SourceFormat.PNG)
+        self.assertEqual(asset.source_path, "assets/source/letters/A.png")
+
+        # Verify defaults
+        self.assertEqual(asset.width, 512)
+        self.assertEqual(asset.height, 512)
+        self.assertTrue(asset.transparent_background)
+        self.assertIsNone(asset.theme)
+        self.assertEqual(asset.tags, [])
+        self.assertEqual(asset.animation_compatible_presets, [])
+        self.assertEqual(asset.export_targets, [])
+        self.assertEqual(asset.notes, "")
+
+    def test_asset_to_dict_all_fields(self):
+        """Test serialization with all fields populated."""
+        asset = Asset(
+            **self.mandatory_kwargs,
+            width=1024,
+            height=1024,
+            transparent_background=False,
+            theme=AssetTheme.NEON,
+            tags=["neon", "glow"],
+            animation_compatible_presets=["pulse", "shake"],
+            export_targets=["gif", "webp"],
+            notes="Requires extra glow"
+        )
+
+        result = asset.to_dict()
+
+        expected = {
+            "id": "letter_A",
+            "name": "Letter A",
+            "category": "letter",
+            "source_format": "png",
+            "source_path": "assets/source/letters/A.png",
+            "width": 1024,
+            "height": 1024,
+            "transparent_background": False,
+            "theme": "neon",
+            "tags": ["neon", "glow"],
+            "animation_compatible_presets": ["pulse", "shake"],
+            "export_targets": ["gif", "webp"],
+            "notes": "Requires extra glow"
+        }
+        self.assertEqual(result, expected)
+
+    def test_asset_from_dict_all_fields(self):
+        """Test deserialization with all fields populated."""
+        data = {
+            "id": "letter_A",
+            "name": "Letter A",
+            "category": "letter",
+            "source_format": "png",
+            "source_path": "assets/source/letters/A.png",
+            "width": 1024,
+            "height": 1024,
+            "transparent_background": False,
+            "theme": "neon",
+            "tags": ["neon", "glow"],
+            "animation_compatible_presets": ["pulse", "shake"],
+            "export_targets": ["gif", "webp"],
+            "notes": "Requires extra glow"
+        }
+
+        asset = Asset.from_dict(data)
+
+        self.assertEqual(asset.width, 1024)
+        self.assertEqual(asset.height, 1024)
+        self.assertFalse(asset.transparent_background)
+        self.assertEqual(asset.theme, AssetTheme.NEON)
+        self.assertEqual(asset.tags, ["neon", "glow"])
+        self.assertEqual(asset.animation_compatible_presets, ["pulse", "shake"])
+        self.assertEqual(asset.export_targets, ["gif", "webp"])
+        self.assertEqual(asset.notes, "Requires extra glow")
+
+    def test_asset_roundtrip(self):
+        """Test serialization and then deserialization results in identical object."""
+        asset1 = Asset(
+            **self.mandatory_kwargs,
+            width=1024,
+            height=1024,
+            transparent_background=False,
+            theme=AssetTheme.NEON,
+            tags=["neon", "glow"],
+            animation_compatible_presets=["pulse", "shake"],
+            export_targets=["gif", "webp"],
+            notes="Requires extra glow"
+        )
+
+        data = asset1.to_dict()
+        asset2 = Asset.from_dict(data)
+
+        self.assertEqual(asset1, asset2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for `pipeline/asset_model/__init__.py`.
📊 **Coverage:** Covered `Asset.to_dict()` and `Asset.from_dict()` for serialization/deserialization, including mandatory fields, default fallbacks, Enum translations, and full data roundtrip capabilities.
✨ **Result:** Improved test coverage and reliability for core data structure conversions.

---
*PR created automatically by Jules for task [14853168161919105240](https://jules.google.com/task/14853168161919105240) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new unit tests only; no production logic changes, with low risk aside from potential brittleness if `Asset` defaults/fields evolve.
> 
> **Overview**
> Adds a new `tests/test_pipeline_asset_model.py` suite covering `Asset.to_dict()`/`Asset.from_dict()` behavior, including enum string conversions, default-value fallbacks when optional fields are omitted, full-field serialization/deserialization, and a round-trip equality check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40cb630b04c783fdf1f8b1c2fe214dceea6a93b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->