### PR TITLE
🧪 Add tests for pipeline manifest generation

### DIFF
--- a/pr_description.txt
+++ b/pr_description.txt
@@ -1,0 +1,11 @@
+🎯 **What:**
+Added a test suite for `pipeline.manifest.generate_pipeline_manifest` which had a testing gap.
+
+📊 **Coverage:**
+- Happy path testing: Ensures manifest is built properly when given correct inputs.
+- Edge cases testing: Handles missing or empty packs directory without failure, returning empty metadata.
+- Error handling testing: Handles and logs exceptions from `PackDefinition.from_file` and `build_pack` to gracefully skip specific files and continue processing.
+- IO error testing: Handles exceptions gracefully if writing the manifest file fails after everything is built.
+
+✨ **Result:**
+Significant test coverage increase for the pipeline manifest generation, increasing reliability for downstream consumption (extension loaders, API, overlay compositor).

--- a/tests/test_pipeline_manifest.py
+++ b/tests/test_pipeline_manifest.py
@@ -1,0 +1,172 @@
+import json
+import unittest
+from unittest.mock import patch, MagicMock
+
+from pipeline.manifest import generate_pipeline_manifest
+
+class TestGeneratePipelineManifest(unittest.TestCase):
+    @patch('pipeline.manifest.json.dump')
+    @patch('pipeline.manifest.open', new_callable=unittest.mock.mock_open)
+    @patch('pipeline.packager.build_pack')
+    @patch('pipeline.packager.PackDefinition')
+    @patch('pipeline.metadata.AssetCatalog')
+    @patch('os.listdir')
+    @patch('os.path.isdir')
+    @patch('os.path.isfile')
+    def test_happy_path(self, mock_isfile, mock_isdir, mock_listdir, mock_asset_catalog, mock_pack_def, mock_build_pack, mock_open, mock_json_dump):
+        mock_isdir.return_value = True
+        mock_listdir.return_value = ['pack1']
+        mock_isfile.return_value = True
+
+        mock_catalog_instance = MagicMock()
+        mock_asset_catalog.return_value = mock_catalog_instance
+
+        mock_asset = MagicMock()
+        mock_asset.name = "Asset 1"
+        mock_asset.category.value = "cat1"
+        mock_catalog_instance.get.return_value = mock_asset
+
+        mock_pack_instance = MagicMock()
+        mock_pack_instance.pack_id = "pack1_id"
+        mock_pack_instance.title = "Pack 1"
+        mock_pack_instance.theme = "light"
+        mock_pack_instance.target_platforms = ["web"]
+        mock_pack_instance.export_formats = ["gif"]
+        mock_pack_def.from_file.return_value = mock_pack_instance
+
+        mock_pack_manifest = MagicMock()
+        mock_entry = MagicMock()
+        mock_entry.asset_id = "asset1_id"
+        mock_entry.preset_id = "preset1"
+        mock_entry.expected_outputs = {"thumbnail": "thumb.png", "gif": "out.gif"}
+        mock_pack_manifest.entries = [mock_entry]
+        mock_build_pack.return_value = mock_pack_manifest
+
+        result = generate_pipeline_manifest(output_path="test_manifest.json")
+
+        self.assertEqual(result["total_packs"], 1)
+        self.assertEqual(result["total_assets"], 1)
+        self.assertEqual(len(result["packs"]), 1)
+        self.assertEqual(result["packs"][0]["pack_id"], "pack1_id")
+        self.assertEqual(result["packs"][0]["entries"][0]["asset_id"], "asset1_id")
+
+    @patch('pipeline.manifest.json.dump')
+    @patch('pipeline.manifest.open', new_callable=unittest.mock.mock_open)
+    @patch('pipeline.metadata.AssetCatalog')
+    @patch('os.listdir')
+    @patch('os.path.isdir')
+    def test_empty_packs_dir(self, mock_isdir, mock_listdir, mock_asset_catalog, mock_open, mock_json_dump):
+        mock_isdir.return_value = True
+        mock_listdir.return_value = []
+
+        result = generate_pipeline_manifest(output_path="test_manifest.json")
+
+        self.assertEqual(result["total_packs"], 0)
+        self.assertEqual(result["total_assets"], 0)
+        self.assertEqual(len(result["packs"]), 0)
+
+    @patch('pipeline.manifest.json.dump')
+    @patch('pipeline.manifest.open', new_callable=unittest.mock.mock_open)
+    @patch('pipeline.metadata.AssetCatalog')
+    @patch('os.listdir')
+    @patch('os.path.isdir')
+    def test_packs_dir_not_dir(self, mock_isdir, mock_listdir, mock_asset_catalog, mock_open, mock_json_dump):
+        mock_isdir.return_value = False
+
+        result = generate_pipeline_manifest(output_path="test_manifest.json")
+
+        self.assertEqual(result["total_packs"], 0)
+        self.assertEqual(result["total_assets"], 0)
+        self.assertEqual(len(result["packs"]), 0)
+
+    @patch('pipeline.manifest.json.dump')
+    @patch('pipeline.manifest.open', new_callable=unittest.mock.mock_open)
+    @patch('pipeline.packager.PackDefinition')
+    @patch('pipeline.metadata.AssetCatalog')
+    @patch('os.listdir')
+    @patch('os.path.isdir')
+    @patch('os.path.isfile')
+    def test_pack_def_exception(self, mock_isfile, mock_isdir, mock_listdir, mock_asset_catalog, mock_pack_def, mock_open, mock_json_dump):
+        mock_isdir.return_value = True
+        mock_listdir.return_value = ['pack1']
+        mock_isfile.return_value = True
+
+        mock_pack_def.from_file.side_effect = Exception("Pack definition error")
+
+        result = generate_pipeline_manifest(output_path="test_manifest.json")
+
+        self.assertEqual(result["total_packs"], 0)
+        self.assertEqual(result["total_assets"], 0)
+        self.assertEqual(len(result["packs"]), 0)
+
+    @patch('pipeline.manifest.json.dump')
+    @patch('pipeline.manifest.open', new_callable=unittest.mock.mock_open)
+    @patch('pipeline.packager.build_pack')
+    @patch('pipeline.packager.PackDefinition')
+    @patch('pipeline.metadata.AssetCatalog')
+    @patch('os.listdir')
+    @patch('os.path.isdir')
+    @patch('os.path.isfile')
+    def test_build_pack_exception(self, mock_isfile, mock_isdir, mock_listdir, mock_asset_catalog, mock_pack_def, mock_build_pack, mock_open, mock_json_dump):
+        mock_isdir.return_value = True
+        mock_listdir.return_value = ['pack1']
+        mock_isfile.return_value = True
+
+        mock_pack_def.from_file.return_value = MagicMock()
+        mock_build_pack.side_effect = Exception("Build pack error")
+
+        result = generate_pipeline_manifest(output_path="test_manifest.json")
+
+        self.assertEqual(result["total_packs"], 0)
+        self.assertEqual(result["total_assets"], 0)
+        self.assertEqual(len(result["packs"]), 0)
+
+    @patch('pipeline.manifest.open', new_callable=unittest.mock.mock_open)
+    @patch('pipeline.packager.build_pack')
+    @patch('pipeline.packager.PackDefinition')
+    @patch('pipeline.metadata.AssetCatalog')
+    @patch('os.listdir')
+    @patch('os.path.isdir')
+    @patch('os.path.isfile')
+    def test_file_write_exception(self, mock_isfile, mock_isdir, mock_listdir, mock_asset_catalog, mock_pack_def, mock_build_pack, mock_open):
+        mock_isdir.return_value = True
+        mock_listdir.return_value = ['pack1']
+        mock_isfile.return_value = True
+
+        mock_catalog_instance = MagicMock()
+        mock_asset_catalog.return_value = mock_catalog_instance
+
+        mock_asset = MagicMock()
+        mock_asset.name = "Asset 1"
+        mock_asset.category.value = "cat1"
+        mock_catalog_instance.get.return_value = mock_asset
+
+        mock_pack_instance = MagicMock()
+        mock_pack_instance.pack_id = "pack1_id"
+        mock_pack_instance.title = "Pack 1"
+        mock_pack_instance.theme = "light"
+        mock_pack_instance.target_platforms = ["web"]
+        mock_pack_instance.export_formats = ["gif"]
+        mock_pack_def.from_file.return_value = mock_pack_instance
+
+        mock_pack_manifest = MagicMock()
+        mock_entry = MagicMock()
+        mock_entry.asset_id = "asset1_id"
+        mock_entry.preset_id = "preset1"
+        mock_entry.expected_outputs = {"thumbnail": "thumb.png", "gif": "out.gif"}
+        mock_pack_manifest.entries = [mock_entry]
+        mock_build_pack.return_value = mock_pack_manifest
+
+        mock_open.side_effect = IOError("File write error")
+
+        # Function should catch and log exception, and still return the manifest dict
+        result = generate_pipeline_manifest(output_path="test_manifest.json")
+
+        self.assertEqual(result["total_packs"], 1)
+        self.assertEqual(result["total_assets"], 1)
+        self.assertEqual(len(result["packs"]), 1)
+        self.assertEqual(result["packs"][0]["pack_id"], "pack1_id")
+        self.assertEqual(result["packs"][0]["entries"][0]["asset_id"], "asset1_id")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** 
Added a test suite for `pipeline.manifest.generate_pipeline_manifest` which had a testing gap.

📊 **Coverage:** 
- Happy path testing: Ensures manifest is built properly when given correct inputs.
- Edge cases testing: Handles missing or empty packs directory without failure, returning empty metadata.
- Error handling testing: Handles and logs exceptions from `PackDefinition.from_file` and `build_pack` to gracefully skip specific files and continue processing.
- IO error testing: Handles exceptions gracefully if writing the manifest file fails after everything is built.

✨ **Result:** 
Significant test coverage increase for the pipeline manifest generation, increasing reliability for downstream consumption (extension loaders, API, overlay compositor).

---
*PR created automatically by Jules for task [9529725169311028557](https://jules.google.com/task/9529725169311028557) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds unit tests only, with no production code changes; risk is limited to potential test brittleness due to heavy mocking of filesystem and packager interactions.
> 
> **Overview**
> Adds a new `tests/test_pipeline_manifest.py` suite to cover `pipeline.manifest.generate_pipeline_manifest`, including the happy path, empty/missing packs directory handling, exceptions from `PackDefinition.from_file`/`build_pack`, and failure to write the output file while still returning the in-memory manifest.
> 
> Also adds `pr_description.txt` documenting the new coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0748b74bde82da675b198ab5ac51cec460a024eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->