### PR TITLE
🧹 [code health] Remove unused annotations import in pipeline/manifest.py

### DIFF
--- a/pipeline/manifest.py
+++ b/pipeline/manifest.py
@@ -56,7 +56,6 @@ The generated JSON has the following top-level structure::
     }
 """
 
-from __future__ import annotations
 
 import json
 import logging


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` in `pipeline/manifest.py`.
💡 **Why:** The project uses Python 3.12, meaning standard generic types and union types are supported natively. This removes dead code and adheres to cleaner standards.
✅ **Verification:** Verified by targeted testing of `pipeline/manifest.py` along with global tests execution.
✨ **Result:** A slightly cleaner file with no functional difference.

---
*PR created automatically by Jules for task [11778398856251208821](https://jules.google.com/task/11778398856251208821) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes an unused `from __future__ import annotations` line with no behavior changes expected.
> 
> **Overview**
> **Code health cleanup:** removes the unused `from __future__ import annotations` import from `pipeline/manifest.py` with no functional changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef70fdf1372318b234c8a61ee490786cf8503bcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->