### PR TITLE
🧪 Add tests for MotionPreset serialization methods

### DIFF
--- a/tests/test_motion_preset.py
+++ b/tests/test_motion_preset.py
@@ -1,0 +1,116 @@
+import unittest
+
+from pipeline.motion_presets.preset import MotionPreset
+
+
+class TestMotionPreset(unittest.TestCase):
+    def test_default_values(self):
+        preset = MotionPreset(id="test_id", name="Test Name")
+
+        self.assertEqual(preset.id, "test_id")
+        self.assertEqual(preset.name, "Test Name")
+        self.assertTrue(preset.loopable)
+        self.assertEqual(preset.duration_ms, 1000)
+        self.assertTrue(preset.alpha_safe)
+        self.assertTrue(preset.overlay_safe)
+        self.assertTrue(preset.sticker_safe)
+        self.assertEqual(preset.recommended_categories, [])
+        self.assertEqual(preset.parameter_schema, {})
+        self.assertEqual(preset.description, "")
+
+    def test_is_recommended_for(self):
+        # When recommended_categories is empty, it works for all
+        preset_empty = MotionPreset(id="1", name="1", recommended_categories=[])
+        self.assertTrue(preset_empty.is_recommended_for("any_category"))
+
+        preset_specific = MotionPreset(
+            id="2", name="2", recommended_categories=["cat1", "cat2"]
+        )
+        self.assertTrue(preset_specific.is_recommended_for("cat1"))
+        self.assertTrue(preset_specific.is_recommended_for("cat2"))
+        self.assertFalse(preset_specific.is_recommended_for("cat3"))
+
+    def test_to_dict(self):
+        preset = MotionPreset(
+            id="pulse",
+            name="Pulse",
+            loopable=False,
+            duration_ms=500,
+            alpha_safe=False,
+            overlay_safe=False,
+            sticker_safe=False,
+            recommended_categories=["cat1"],
+            parameter_schema={"param1": "val1"},
+            description="Pulse effect",
+        )
+
+        expected_dict = {
+            "id": "pulse",
+            "name": "Pulse",
+            "loopable": False,
+            "duration_ms": 500,
+            "alpha_safe": False,
+            "overlay_safe": False,
+            "sticker_safe": False,
+            "recommended_categories": ["cat1"],
+            "parameter_schema": {"param1": "val1"},
+            "description": "Pulse effect",
+        }
+
+        self.assertEqual(preset.to_dict(), expected_dict)
+
+    def test_from_dict(self):
+        data = {
+            "id": "glow",
+            "name": "Glow",
+            "loopable": True,
+            "duration_ms": 2000,
+            "alpha_safe": True,
+            "overlay_safe": True,
+            "sticker_safe": True,
+            "recommended_categories": ["cat2"],
+            "parameter_schema": {"param2": "val2"},
+            "description": "Glow effect",
+        }
+
+        preset = MotionPreset.from_dict(data)
+
+        self.assertEqual(preset.id, "glow")
+        self.assertEqual(preset.name, "Glow")
+        self.assertTrue(preset.loopable)
+        self.assertEqual(preset.duration_ms, 2000)
+        self.assertTrue(preset.alpha_safe)
+        self.assertTrue(preset.overlay_safe)
+        self.assertTrue(preset.sticker_safe)
+        self.assertEqual(preset.recommended_categories, ["cat2"])
+        self.assertEqual(preset.parameter_schema, {"param2": "val2"})
+        self.assertEqual(preset.description, "Glow effect")
+
+    def test_from_dict_with_missing_optional_fields(self):
+        data = {"id": "minimal", "name": "Minimal"}
+
+        preset = MotionPreset.from_dict(data)
+
+        self.assertEqual(preset.id, "minimal")
+        self.assertEqual(preset.name, "Minimal")
+        self.assertTrue(preset.loopable)
+        self.assertEqual(preset.duration_ms, 1000)
+        self.assertTrue(preset.alpha_safe)
+        self.assertTrue(preset.overlay_safe)
+        self.assertTrue(preset.sticker_safe)
+        self.assertEqual(preset.recommended_categories, [])
+        self.assertEqual(preset.parameter_schema, {})
+        self.assertEqual(preset.description, "")
+
+    def test_repr(self):
+        preset = MotionPreset(
+            id="test_repr", name="Name", duration_ms=1234, loopable=False
+        )
+        self.assertEqual(
+            repr(preset),
+            "<MotionPreset id='test_repr' duration_ms=1234 loopable=False>",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** Added tests/test_motion_preset.py to test the MotionPreset dataclass, addressing a testing gap for pure logic functions.
📊 **Coverage:** Added tests for to_dict and from_dict (with and without optional fields), as well as default values, is_recommended_for, and __repr__.
✨ **Result:** Increased test coverage and reliability for preset serialization.

---
*PR created automatically by Jules for task [16490169529426685895](https://jules.google.com/task/16490169529426685895) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new test file only and does not change production logic.
> 
> **Overview**
> Adds a new `tests/test_motion_preset.py` suite to validate `MotionPreset` behavior, including default field values, `is_recommended_for` category matching, `to_dict`/`from_dict` round-trips (including missing optional fields), and a stable `__repr__` output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c36dad20751046aab7f10be1f7e0404231158c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->