### PR TITLE
🔒 Security: Fix missing Mini App authentication in catalog pack feature and react endpoints

### DIFF
--- a/api.py
+++ b/api.py
@@ -860,18 +860,17 @@ def catalog_pack_detail(pack_name):
 
 
 @app.route("/api/catalog/packs/<pack_name>/react", methods=["POST"])
+@require_miniapp_auth
 def catalog_pack_react(pack_name):
     """
     POST /api/catalog/packs/<name>/react
-    Body: {"user_id": int, "type": "like"|"dislike"}
-    No API key required (uses user_id from request body).
+    Body: {"type": "like"|"dislike"}
+    Requires Mini App authentication.
     """
     data = request.get_json(silent=True) or {}
-    user_id = data.get("user_id")
+    user_id = g.miniapp_user_id
     reaction = data.get("type", "")
 
-    if not user_id or not str(user_id).lstrip("-").isdigit():
-        return err("Missing or invalid user_id", 400, "missing_param")
     if reaction not in ("like", "dislike"):
         return err("type must be 'like' or 'dislike'", 400, "invalid_param")
 
@@ -956,20 +955,20 @@ def catalog_pack_react(pack_name):
 
 
 @app.route("/api/catalog/packs/<pack_name>/feature", methods=["POST"])
+@require_miniapp_auth
 def catalog_pack_feature(pack_name):
     """
     POST /api/catalog/packs/<name>/feature
-    Body: {"user_id": int, "title": str, "description": str, "type": str}
+    Body: {"title": str, "description": str, "type": str}
     Allows a Mini App user to feature a pack in the catalog.
+    Requires Mini App authentication.
     """
     data = request.get_json(silent=True) or {}
-    user_id = data.get("user_id")
+    user_id = g.miniapp_user_id
     title = str(data.get("title", "")).strip()
     description = str(data.get("description", "")).strip()
     pack_type = data.get("type", "image")
 
-    if not user_id or not str(user_id).lstrip("-").isdigit():
-        return err("Missing or invalid user_id", 400, "missing_param")
     if not title:
         return err("title is required", 400, "missing_param")
     if pack_type not in ("image", "animated", "video"):

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -252,6 +252,22 @@ class TestRequireMiniappAuth(ApiTestBase):
         self.assertEqual(resp.status_code, 401)
         data = json.loads(resp.data)
         self.assertFalse(data["ok"])
+
+class TestCatalogFeatureReactAuth(ApiTestBase):
+    def test_feature_requires_auth(self):
+        from stixmagic.telegram_auth import TelegramInitDataError
+        with patch("api.validate_init_data", side_effect=TelegramInitDataError("Missing")):
+            resp = self.client.post("/api/catalog/packs/mypack/feature", json={"title": "foo", "type": "image"})
+        self.assertEqual(resp.status_code, 401)
+        data = resp.get_json()
+        self.assertEqual(data["error"]["code"], "miniapp_unauthorized")
+
+    def test_react_requires_auth(self):
+        from stixmagic.telegram_auth import TelegramInitDataError
+        with patch("api.validate_init_data", side_effect=TelegramInitDataError("Missing")):
+            resp = self.client.post("/api/catalog/packs/mypack/react", json={"type": "like"})
+        self.assertEqual(resp.status_code, 401)
+        data = resp.get_json()
         self.assertEqual(data["error"]["code"], "miniapp_unauthorized")
 
     def test_invalid_init_data_returns_401(self):


### PR DESCRIPTION
🎯 **What:**
The endpoints `/api/catalog/packs/<pack_name>/feature` and `/api/catalog/packs/<pack_name>/react` did not require authentication. They trusted the `user_id` provided in the JSON body without verifying the identity of the user.

⚠️ **Risk:**
A malicious actor could send requests to these endpoints with arbitrary `user_id` values, forging likes, dislikes, and featuring actions. They could heavily boost their own packs or maliciously downvote competitor packs, destroying trust and accuracy of the catalog's reputation metrics. Since `user_id` was fully controlled by the requester, this bypassed any rate limits or reputation systems tied to the account.

🛡️ **Solution:**
Added the `@require_miniapp_auth` decorator to both endpoints. The `user_id` is now securely populated from the validated session via `g.miniapp_user_id` rather than blindly trusting the request body. Both endpoints now refuse unauthorized requests and use the authenticated user ID for database operations. Also added unit tests in `tests/test_api_helpers.py` to verify this new authentication requirement works as expected.

---
*PR created automatically by Jules for task [9105890447670658033](https://jules.google.com/task/9105890447670658033) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens authentication on two public-facing endpoints and changes request contract by removing body-supplied `user_id`, which could break existing clients but reduces spoofing risk.
> 
> **Overview**
> **Secures catalog reputation actions.** The `POST /api/catalog/packs/<pack_name>/react` and `.../feature` endpoints now require Telegram Mini App authentication via `@require_miniapp_auth` and derive `user_id` from `g.miniapp_user_id` instead of trusting a JSON `user_id`.
> 
> Adds unit coverage ensuring both endpoints return `401` with `miniapp_unauthorized` when init data is missing/invalid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5984758478f52bc212e096577425a15b1e0a824. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->