### PR TITLE
🧪 Add missing tests for catalog.py

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -38,3 +38,7 @@
 ## 2026-05-13 - Loop Invariant Code Motion and Lookup Optimization
 **Learning:** Found that `pipeline/packager/__init__.py::build_pack` had an O(Assets * Presets * Formats) nested loop that repeatedly performed identical dictionary lookups and conditional checks (like checking if the format was 'thumbnail') which were invariant for a given asset or the entire execution. This resulted in redundant work and slower execution.
 **Action:** Extracted loop invariants and pre-computed static values (e.g. format tuples, constant thumbnail paths) outside the inner loops. This minimizes repeated dictionary accesses and condition evaluations, yielding an ~23% performance improvement in manifest generation.
+
+## 2026-05-19 - Testing Pure Logic Modules
+**Learning:** Found that `pipeline/motion_presets/catalog.py` lacked test coverage despite being a pure logic module. Testing pure logic is straightforward and crucial for ensuring the integrity of the data structures and accessor methods.
+**Action:** Always add corresponding test files (e.g., `test_motion_presets_catalog.py`) for modules containing dictionaries and simple getter/listing functions. Ensure that the test suite covers the contents of the structures as well as the behavior of the accessor functions, including edge cases like `KeyError` handling.

--- a/tests/test_motion_presets_catalog.py
+++ b/tests/test_motion_presets_catalog.py
@@ -1,0 +1,70 @@
+"""
+Tests for pipeline/motion_presets/catalog.py - Motion preset catalog.
+"""
+
+import unittest
+
+from pipeline.motion_presets.catalog import PRESETS, get_preset, list_presets
+from pipeline.motion_presets.preset import MotionPreset
+
+
+class TestMotionPresetsCatalog(unittest.TestCase):
+
+    def test_presets_dict_contains_expected_presets(self):
+        """Test that PRESETS dict contains all built-in presets."""
+        self.assertIsInstance(PRESETS, dict)
+        self.assertGreaterEqual(len(PRESETS), 10)
+
+        expected_ids = [
+            "pulse",
+            "glow",
+            "wobble",
+            "bounce",
+            "orbit",
+            "glitch",
+            "sparkle",
+            "particle_burst",
+            "laser_sweep",
+            "signal_flash",
+        ]
+
+        for expected_id in expected_ids:
+            self.assertIn(expected_id, PRESETS)
+            preset = PRESETS[expected_id]
+            self.assertIsInstance(preset, MotionPreset)
+            self.assertEqual(preset.id, expected_id)
+
+    def test_get_preset_success(self):
+        """Test getting a valid preset by ID."""
+        preset = get_preset("pulse")
+        self.assertIsInstance(preset, MotionPreset)
+        self.assertEqual(preset.id, "pulse")
+
+    def test_get_preset_key_error(self):
+        """Test getting an invalid preset raises KeyError."""
+        with self.assertRaises(KeyError) as context:
+            get_preset("non_existent_preset_id_123")
+
+        self.assertIn(
+            "Unknown motion preset 'non_existent_preset_id_123'", str(context.exception)
+        )
+
+    def test_list_presets(self):
+        """Test listing all presets returns a list of MotionPreset objects."""
+        presets_list = list_presets()
+        self.assertIsInstance(presets_list, list)
+        self.assertEqual(len(presets_list), len(PRESETS))
+
+        for preset in presets_list:
+            self.assertIsInstance(preset, MotionPreset)
+
+    def test_list_presets_matches_dict_values(self):
+        """Test list_presets() returns the same instances as PRESETS.values()."""
+        presets_list = list_presets()
+        presets_values = list(PRESETS.values())
+
+        self.assertEqual(presets_list, presets_values)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The `pipeline/motion_presets/catalog.py` module lacked a test file despite containing pure logic and dictionary structures. This PR introduces a dedicated test suite for this catalog.

📊 **Coverage:** The new tests cover:
- Successful retrieval of a preset via `get_preset()`.
- Error handling (verifying `KeyError` is raised for invalid IDs) in `get_preset()`.
- Successful return of all registered presets via `list_presets()`, confirming the length matches the length of the `PRESETS` dictionary.
- Direct verification that the `PRESETS` dictionary contains all expected preset keys mapped to instances of `MotionPreset` objects.

✨ **Result:** Test coverage significantly improved for the `pipeline/motion_presets/catalog.py` module, establishing a robust safety net for future refactoring and ensuring safe retrieval of motion presets.

---
*PR created automatically by Jules for task [2034856897019694848](https://jules.google.com/task/2034856897019694848) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new `unittest` suite and a documentation note without changing runtime behavior.
> 
> **Overview**
> Adds `tests/test_motion_presets_catalog.py` to cover `pipeline.motion_presets.catalog` helpers and data, including preset registration, `get_preset()` success/`KeyError` behavior, and `list_presets()` output consistency.
> 
> Updates `.jules/bolt.md` with a new entry emphasizing adding tests for pure-logic modules like the motion preset catalog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc3e03a2bd669e8ab0783bdb9a31006ca05c9fdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->