### PR TITLE
🧹 Remove unused validate_init_data import from stixmagic/__init__.py

### DIFF
--- a/stixmagic/__init__.py
+++ b/stixmagic/__init__.py
@@ -15,4 +15,4 @@ from .contracts import (  # noqa: F401
     START_PAYLOAD_MANAGE,
 )
 from .settings import AppSettings, get_settings  # noqa: F401
-from .telegram_auth import TelegramInitDataError, validate_init_data  # noqa: F401
+from .telegram_auth import TelegramInitDataError  # noqa: F401


### PR DESCRIPTION
🎯 **What:** Removed unused `validate_init_data` import from `stixmagic/__init__.py`.
💡 **Why:** `stixmagic/__init__.py` exported `TelegramInitDataError` and `validate_init_data`, but `validate_init_data` is only imported directly from `stixmagic.telegram_auth` throughout the codebase, making its export here unused. Removing dead imports improves maintainability and decreases coupling.
✅ **Verification:** Verified by checking occurrences of `from stixmagic import validate_init_data` and running the test suite to ensure no downstream dependencies were negatively affected.
✨ **Result:** Cleaned up exports and improved code health.

---
*PR created automatically by Jules for task [4084412199762943147](https://jules.google.com/task/4084412199762943147) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only removes an unused re-export from `stixmagic/__init__.py` and does not change the implementation of `validate_init_data` itself.
> 
> **Overview**
> Removes the `validate_init_data` re-export from `stixmagic/__init__.py`, leaving only `TelegramInitDataError` exported from `telegram_auth`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3703e143f9c1792ee4ed6647ed9710035fd0e0c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->