### PR TITLE
🧹 Code Health: Simplify export_all orchestrator

### DIFF
--- a/pipeline/exporters/__init__.py
+++ b/pipeline/exporters/__init__.py
@@ -302,6 +302,54 @@ def export_thumbnail(
 
 # ── Aggregate exporter ────────────────────────────────────────
 
+def _get_dispatch_map(renders_root: str) -> dict:
+    """Return mapping of formats to their exporter functions and output dirs."""
+    return {
+        "gif":          (export_gif,          os.path.join(renders_root, "gif")),
+        "webp":         (export_animated_webp, os.path.join(renders_root, "webp")),
+        "webm":         (export_webm,          os.path.join(renders_root, "webm")),
+        "mov":          (export_mov,           os.path.join(renders_root, "mov")),
+        "png_sequence": (export_png_sequence,  os.path.join(renders_root, "png_sequences")),
+    }
+
+
+def _execute_export(
+    fmt: str,
+    source_path: str,
+    preset: MotionPreset,
+    renders_root: str,
+    result: ExportResult,
+    dispatch_map: dict,
+) -> None:
+    """Execute export for a single format and update the result object."""
+    if fmt == "thumbnail":
+        path = export_thumbnail(source_path, os.path.join(renders_root, "thumbnails"))
+        if path:
+            result.thumbnail = path
+        else:
+            result.errors.append("thumbnail export failed")
+        return
+
+    if fmt not in dispatch_map:
+        result.errors.append(f"unknown format: {fmt!r}")
+        return
+
+    exporter_fn, out_dir = dispatch_map[fmt]
+    try:
+        path = exporter_fn(source_path, preset, out_dir)
+    except Exception as exc:
+        result.errors.append(f"{fmt} export raised: {exc}")
+        path = None
+
+    if path:
+        if fmt == "png_sequence":
+            result.png_sequence_dir = path
+        else:
+            setattr(result, fmt, path)
+    else:
+        result.errors.append(f"{fmt} export returned None")
+
+
 def export_all(
     asset_id: str,
     source_path: str,
@@ -338,41 +386,9 @@ def export_all(
 
     result = ExportResult(asset_id=asset_id, preset_id=preset.id)
 
-    _dispatch = {
-        "gif":          (export_gif,          os.path.join(renders_root, "gif")),
-        "webp":         (export_animated_webp, os.path.join(renders_root, "webp")),
-        "webm":         (export_webm,          os.path.join(renders_root, "webm")),
-        "mov":          (export_mov,           os.path.join(renders_root, "mov")),
-        "png_sequence": (export_png_sequence,  os.path.join(renders_root, "png_sequences")),
-    }
-
+    dispatch_map = _get_dispatch_map(renders_root)
     for fmt in formats:
-        if fmt == "thumbnail":
-            path = export_thumbnail(source_path, os.path.join(renders_root, "thumbnails"))
-            if path:
-                result.thumbnail = path
-            else:
-                result.errors.append("thumbnail export failed")
-            continue
-
-        if fmt not in _dispatch:
-            result.errors.append(f"unknown format: {fmt!r}")
-            continue
-
-        exporter_fn, out_dir = _dispatch[fmt]
-        try:
-            path = exporter_fn(source_path, preset, out_dir)
-        except Exception as exc:
-            result.errors.append(f"{fmt} export raised: {exc}")
-            path = None
-
-        if path:
-            if fmt == "png_sequence":
-                result.png_sequence_dir = path
-            else:
-                setattr(result, fmt, path)
-        else:
-            result.errors.append(f"{fmt} export returned None")
+        _execute_export(fmt, source_path, preset, renders_root, result, dispatch_map)
 
     return result
 


### PR DESCRIPTION
🎯 **What:** Extracted the format mapping `_dispatch` into a `_get_dispatch_map()` helper and the individual exporter loop logic into an `_execute_export()` helper function within `pipeline/exporters/__init__.py`.

💡 **Why:** The `export_all()` orchestrator function was overly complex, handling format mapping logic, export thumbnail special casing, loop control flow, exception catching, and `ExportResult` property assignments. Extracting these steps into dedicated helper functions vastly simplifies the `export_all` flow, increasing readability and maintainability.

✅ **Verification:** Verified that structural integrity was maintained by compiling with `python -m py_compile pipeline/exporters/__init__.py`. Ran the full test suite via `TELEGRAM_BOT_TOKEN=dummy STIXMAGIC_API_KEY=supersecret poetry run python -m unittest discover tests` and verified that no existing tests were newly broken by this change.

✨ **Result:** A cleaner, modular `export_all` orchestrator.

---
*PR created automatically by Jules for task [1600275176905876618](https://jules.google.com/task/1600275176905876618) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to `pipeline/exporters/__init__.py` that preserves export behavior but could subtly change error/attribute handling if the helper logic diverges from the prior inline loop.
> 
> **Overview**
> Refactors `export_all()` by extracting the per-format dispatch table into `_get_dispatch_map()` and the per-format execution/error-handling logic into `_execute_export()`.
> 
> Behavior is intended to stay the same (including the special-cased `thumbnail` path and `ExportResult` field updates), but the orchestration loop is now a thin wrapper around these helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49e2f4cb2a27dab1ad3ae044465dd5a1ae25d899. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->