### PR TITLE
🔒 Security: Fix unauthenticated access in catalog endpoints

### DIFF
--- a/api.py
+++ b/api.py
@@ -860,18 +860,15 @@ def catalog_pack_detail(pack_name):
 
 
 @app.route("/api/catalog/packs/<pack_name>/react", methods=["POST"])
+@require_miniapp_auth
 def catalog_pack_react(pack_name):
     """
     POST /api/catalog/packs/<name>/react
-    Body: {"user_id": int, "type": "like"|"dislike"}
-    No API key required (uses user_id from request body).
+    Body: {"type": "like"|"dislike"}
     """
     data = request.get_json(silent=True) or {}
-    user_id = data.get("user_id")
+    user_id = g.miniapp_user_id
     reaction = data.get("type", "")
-
-    if not user_id or not str(user_id).lstrip("-").isdigit():
-        return err("Missing or invalid user_id", 400, "missing_param")
     if reaction not in ("like", "dislike"):
         return err("type must be 'like' or 'dislike'", 400, "invalid_param")
 
@@ -956,20 +953,18 @@ def catalog_pack_react(pack_name):
 
 
 @app.route("/api/catalog/packs/<pack_name>/feature", methods=["POST"])
+@require_miniapp_auth
 def catalog_pack_feature(pack_name):
     """
     POST /api/catalog/packs/<name>/feature
-    Body: {"user_id": int, "title": str, "description": str, "type": str}
+    Body: {"title": str, "description": str, "type": str}
     Allows a Mini App user to feature a pack in the catalog.
     """
     data = request.get_json(silent=True) or {}
-    user_id = data.get("user_id")
+    user_id = g.miniapp_user_id
     title = str(data.get("title", "")).strip()
     description = str(data.get("description", "")).strip()
     pack_type = data.get("type", "image")
-
-    if not user_id or not str(user_id).lstrip("-").isdigit():
-        return err("Missing or invalid user_id", 400, "missing_param")
     if not title:
         return err("title is required", 400, "missing_param")
     if pack_type not in ("image", "animated", "video"):


### PR DESCRIPTION
🎯 **What:** 
The `catalog_pack_feature` and `catalog_pack_react` API endpoints did not properly authenticate requests, allowing anyone to act as any user by providing a `user_id` parameter.

⚠️ **Risk:** 
Attackers could send arbitrary JSON payloads featuring random packs or manipulating reaction counts on packs, potentially using any user's ID because the endpoints relied on client-supplied data rather than authenticated session data.

🛡️ **Solution:** 
The endpoints now use the `@require_miniapp_auth` decorator which requires valid Telegram Mini App Init Data in headers to authenticate the request. Furthermore, the `user_id` is now sourced securely from the validated session via `g.miniapp_user_id` instead of the request body.

---
*PR created automatically by Jules for task [16455897054312063199](https://jules.google.com/task/16455897054312063199) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens authentication on two public-facing catalog write endpoints; main risk is breaking existing clients that were sending `user_id` in the body or not providing Telegram init data.
> 
> **Overview**
> Locks down catalog write actions by requiring `@require_miniapp_auth` on `POST /api/catalog/packs/<pack_name>/react` and `POST /api/catalog/packs/<pack_name>/feature`.
> 
> Both endpoints stop accepting a client-supplied `user_id` and instead derive the acting user from `g.miniapp_user_id` (validated Telegram Mini App init data), removing the prior `user_id` input validation and updating the documented request bodies accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b08018b257837df88bf40bcd1b3e8990312e990c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->