### PR TITLE
🧪 Add tests for motion presets catalog

### DIFF
--- a/tests/test_pipeline_motion_presets_catalog.py
+++ b/tests/test_pipeline_motion_presets_catalog.py
@@ -1,0 +1,35 @@
+import unittest
+
+from pipeline.motion_presets.catalog import PRESETS, get_preset, list_presets
+from pipeline.motion_presets.preset import MotionPreset
+
+
+class TestMotionPresetsCatalog(unittest.TestCase):
+    def test_presets_dict(self):
+        self.assertIsInstance(PRESETS, dict)
+        self.assertTrue(len(PRESETS) > 0)
+        for key, preset in PRESETS.items():
+            self.assertIsInstance(key, str)
+            self.assertIsInstance(preset, MotionPreset)
+            self.assertEqual(key, preset.id)
+
+    def test_get_preset_success(self):
+        preset_id = list(PRESETS.keys())[0]
+        preset = get_preset(preset_id)
+        self.assertIsInstance(preset, MotionPreset)
+        self.assertEqual(preset.id, preset_id)
+
+    def test_get_preset_failure(self):
+        with self.assertRaises(KeyError) as context:
+            get_preset("invalid_preset_id_that_does_not_exist")
+        self.assertIn("Unknown motion preset", str(context.exception))
+
+    def test_list_presets(self):
+        presets_list = list_presets()
+        self.assertIsInstance(presets_list, list)
+        self.assertEqual(len(presets_list), len(PRESETS))
+        for preset in presets_list:
+            self.assertIsInstance(preset, MotionPreset)
+
+        # Verify the list contents match the dictionary values
+        self.assertEqual(presets_list, list(PRESETS.values()))


### PR DESCRIPTION
🎯 What: Added unit tests for pipeline/motion_presets/catalog.py.
📊 Coverage: Covered PRESETS dictionary, get_preset, and list_presets.
✨ Result: Increased test coverage for pipeline motion presets.

---
*PR created automatically by Jules for task [5200114160541237642](https://jules.google.com/task/5200114160541237642) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds isolated unit tests only, exercising `PRESETS`, `get_preset` error handling, and `list_presets` ordering without changing production code.
> 
> **Overview**
> Adds a new `unittest` suite for `pipeline.motion_presets.catalog`, asserting `PRESETS` is populated with `MotionPreset` instances keyed by `preset.id`, `get_preset` returns the expected preset and raises a `KeyError` for unknown ids, and `list_presets` returns the catalog values in order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f8f78fdea88960568ec5d43ec8b4e3469b57863. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->