### PR TITLE
🧪 Add tests for pipeline/asset_model/__init__.py

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -38,3 +38,7 @@
 ## 2026-05-13 - Loop Invariant Code Motion and Lookup Optimization
 **Learning:** Found that `pipeline/packager/__init__.py::build_pack` had an O(Assets * Presets * Formats) nested loop that repeatedly performed identical dictionary lookups and conditional checks (like checking if the format was 'thumbnail') which were invariant for a given asset or the entire execution. This resulted in redundant work and slower execution.
 **Action:** Extracted loop invariants and pre-computed static values (e.g. format tuples, constant thumbnail paths) outside the inner loops. This minimizes repeated dictionary accesses and condition evaluations, yielding an ~23% performance improvement in manifest generation.
+
+## 2024-05-19 - Added tests for pipeline/asset_model/__init__.py
+**Learning:** Found a missing test file for `pipeline/asset_model/__init__.py`. Pure logic functions such as `to_dict` and `from_dict` inside data models are easy and important to test to prevent regressions.
+**Action:** Implemented tests covering default parameter instantiation and dictionary serialization (both minimal and full paths). This improves codebase reliability and provides a safety net for future refactoring of the `Asset` dataclass.

--- a/tests/test_pipeline_asset_model.py
+++ b/tests/test_pipeline_asset_model.py
@@ -1,0 +1,136 @@
+import unittest
+from pipeline.asset_model import Asset, AssetCategory, SourceFormat, AssetTheme
+
+class TestAssetModel(unittest.TestCase):
+    def test_asset_defaults(self):
+        asset = Asset(
+            id="test_id",
+            name="Test Name",
+            category=AssetCategory.LETTER,
+            source_format=SourceFormat.PNG,
+            source_path="path/to/source.png"
+        )
+        self.assertEqual(asset.id, "test_id")
+        self.assertEqual(asset.name, "Test Name")
+        self.assertEqual(asset.category, AssetCategory.LETTER)
+        self.assertEqual(asset.source_format, SourceFormat.PNG)
+        self.assertEqual(asset.source_path, "path/to/source.png")
+        self.assertEqual(asset.width, 512)
+        self.assertEqual(asset.height, 512)
+        self.assertTrue(asset.transparent_background)
+        self.assertIsNone(asset.theme)
+        self.assertEqual(asset.tags, [])
+        self.assertEqual(asset.animation_compatible_presets, [])
+        self.assertEqual(asset.export_targets, [])
+        self.assertEqual(asset.notes, "")
+
+    def test_to_dict_minimal(self):
+        asset = Asset(
+            id="test_id",
+            name="Test Name",
+            category=AssetCategory.LETTER,
+            source_format=SourceFormat.PNG,
+            source_path="path/to/source.png"
+        )
+        d = asset.to_dict()
+        self.assertEqual(d["id"], "test_id")
+        self.assertEqual(d["name"], "Test Name")
+        self.assertEqual(d["category"], AssetCategory.LETTER.value)
+        self.assertEqual(d["source_format"], SourceFormat.PNG.value)
+        self.assertEqual(d["source_path"], "path/to/source.png")
+        self.assertEqual(d["width"], 512)
+        self.assertEqual(d["height"], 512)
+        self.assertTrue(d["transparent_background"])
+        self.assertIsNone(d["theme"])
+        self.assertEqual(d["tags"], [])
+        self.assertEqual(d["animation_compatible_presets"], [])
+        self.assertEqual(d["export_targets"], [])
+        self.assertEqual(d["notes"], "")
+
+    def test_to_dict_full(self):
+        asset = Asset(
+            id="test_id_full",
+            name="Test Name Full",
+            category=AssetCategory.NUMBER,
+            source_format=SourceFormat.SVG,
+            source_path="path/to/source_full.svg",
+            width=1024,
+            height=768,
+            transparent_background=False,
+            theme=AssetTheme.NEON,
+            tags=["tag1", "tag2"],
+            animation_compatible_presets=["preset1"],
+            export_targets=["gif"],
+            notes="some notes"
+        )
+        d = asset.to_dict()
+        self.assertEqual(d["id"], "test_id_full")
+        self.assertEqual(d["name"], "Test Name Full")
+        self.assertEqual(d["category"], AssetCategory.NUMBER.value)
+        self.assertEqual(d["source_format"], SourceFormat.SVG.value)
+        self.assertEqual(d["source_path"], "path/to/source_full.svg")
+        self.assertEqual(d["width"], 1024)
+        self.assertEqual(d["height"], 768)
+        self.assertFalse(d["transparent_background"])
+        self.assertEqual(d["theme"], AssetTheme.NEON.value)
+        self.assertEqual(d["tags"], ["tag1", "tag2"])
+        self.assertEqual(d["animation_compatible_presets"], ["preset1"])
+        self.assertEqual(d["export_targets"], ["gif"])
+        self.assertEqual(d["notes"], "some notes")
+
+    def test_from_dict_minimal(self):
+        data = {
+            "id": "test_id",
+            "name": "Test Name",
+            "category": "letter",
+            "source_format": "png",
+            "source_path": "path/to/source.png"
+        }
+        asset = Asset.from_dict(data)
+        self.assertEqual(asset.id, "test_id")
+        self.assertEqual(asset.name, "Test Name")
+        self.assertEqual(asset.category, AssetCategory.LETTER)
+        self.assertEqual(asset.source_format, SourceFormat.PNG)
+        self.assertEqual(asset.source_path, "path/to/source.png")
+        self.assertEqual(asset.width, 512)
+        self.assertEqual(asset.height, 512)
+        self.assertTrue(asset.transparent_background)
+        self.assertIsNone(asset.theme)
+        self.assertEqual(asset.tags, [])
+        self.assertEqual(asset.animation_compatible_presets, [])
+        self.assertEqual(asset.export_targets, [])
+        self.assertEqual(asset.notes, "")
+
+    def test_from_dict_full(self):
+        data = {
+            "id": "test_id_full",
+            "name": "Test Name Full",
+            "category": "number",
+            "source_format": "svg",
+            "source_path": "path/to/source_full.svg",
+            "width": 1024,
+            "height": 768,
+            "transparent_background": False,
+            "theme": "neon",
+            "tags": ["tag1", "tag2"],
+            "animation_compatible_presets": ["preset1"],
+            "export_targets": ["gif"],
+            "notes": "some notes"
+        }
+        asset = Asset.from_dict(data)
+        self.assertEqual(asset.id, "test_id_full")
+        self.assertEqual(asset.name, "Test Name Full")
+        self.assertEqual(asset.category, AssetCategory.NUMBER)
+        self.assertEqual(asset.source_format, SourceFormat.SVG)
+        self.assertEqual(asset.source_path, "path/to/source_full.svg")
+        self.assertEqual(asset.width, 1024)
+        self.assertEqual(asset.height, 768)
+        self.assertFalse(asset.transparent_background)
+        self.assertEqual(asset.theme, AssetTheme.NEON)
+        self.assertEqual(asset.tags, ["tag1", "tag2"])
+        self.assertEqual(asset.animation_compatible_presets, ["preset1"])
+        self.assertEqual(asset.export_targets, ["gif"])
+        self.assertEqual(asset.notes, "some notes")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** Added tests to cover the `Asset` dataclass in `pipeline/asset_model/__init__.py`.
📊 **Coverage:** Covered default value initialization, the `to_dict` serialization method, and the `from_dict` deserialization method with both minimal and full data cases.
✨ **Result:** Improved test coverage for the asset data model, ensuring serialization and instantiation behave as expected.

---
*PR created automatically by Jules for task [14834766630560312629](https://jules.google.com/task/14834766630560312629) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to new unit tests and an internal markdown log, with no production code modifications.
> 
> **Overview**
> Adds a new `tests/test_pipeline_asset_model.py` suite that validates `Asset` default values plus `to_dict`/`from_dict` round-tripping for both minimal and fully-populated inputs.
> 
> Updates `.jules/bolt.md` to record the addition of these tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e40f408936ed127a1e19518f7d61ecf3b55faf67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->