### PR TITLE
🧹 Remove unused `from __future__ import annotations` from `pipeline/manifest.py`

### DIFF
--- a/pipeline/manifest.py
+++ b/pipeline/manifest.py
@@ -56,7 +56,6 @@ The generated JSON has the following top-level structure::
     }
 """
 
-from __future__ import annotations
 
 import json
 import logging


### PR DESCRIPTION
🎯 What: Removed the unused `from __future__ import annotations` import from `pipeline/manifest.py`.
💡 Why: The codebase targets Python 3.12, where this import is largely unnecessary for general usage since postponed evaluation of annotations is the default behavior or standard built-in collections can be used directly for type hinting. This improves code health by removing unneeded legacy cruft.
✅ Verification: Ran the test suite. Although there were pre-existing failures in unrelated files, no new issues were introduced by this removal. Also ran the script directly to verify it works without the import.
✨ Result: Cleaner, more idiomatic code for Python 3.12.

---
*PR created automatically by Jules for task [10053001271244079536](https://jules.google.com/task/10053001271244079536) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a no-op cleanup that only removes an unused import and should not affect runtime behavior.
> 
> **Overview**
> **Cleanup:** removes the unused `from __future__ import annotations` line from `pipeline/manifest.py` to keep the module idiomatic for the project’s Python version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92741d4ae08a307bd598ef539cb25ffd4947f298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->