### PR TITLE
🧹 Remove unused future annotations import from pipeline/manifest.py

### DIFF
--- a/pipeline/manifest.py
+++ b/pipeline/manifest.py
@@ -56,8 +56,6 @@ The generated JSON has the following top-level structure::
     }
 """
 
-from __future__ import annotations
-
 import json
 import logging
 import os


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` statement and associated empty lines from `pipeline/manifest.py`.
💡 **Why:** As the project targets Python 3.12, the `from __future__ import annotations` is not strictly necessary unless resolving forward reference types. Furthermore, it was totally unused in this file and safe to remove, slightly reducing clutter and adhering to leaner, up-to-date Python practices.
✅ **Verification:** Verified the file still imports correctly in python 3.12 syntax and ran the main test suite (`python -m unittest discover tests`) to confirm it didn't introduce any new regressions.
✨ **Result:** Improved code health by removing an obsolete and unused import, keeping the codebase clean.

---
*PR created automatically by Jules for task [17608956312539614063](https://jules.google.com/task/17608956312539614063) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup: removes an unused `from __future__ import annotations` line with no behavior or API changes.
> 
> **Overview**
> Removes the unused `from __future__ import annotations` import (and adjacent blank lines) from `pipeline/manifest.py`, relying on Python 3.12 defaults with no functional changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10c574f89e9198bc79724af524e40b276db5c9d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->