### PR TITLE
🧹 Remove unused START_PAYLOAD variables from stixmagic/__init__.py

### DIFF
--- a/stixmagic/__init__.py
+++ b/stixmagic/__init__.py
@@ -8,11 +8,9 @@ from .contracts import (  # noqa: F401
     PACK_TYPE_VIDEO,
     PACK_TYPES,
     PRODUCT_NAME,
-    START_PAYLOAD_ADD,
-    START_PAYLOAD_CREATE,
-    START_PAYLOAD_FEATURE,
-    START_PAYLOAD_MAGIC,
-    START_PAYLOAD_MANAGE,
 )
 from .settings import AppSettings, get_settings  # noqa: F401
-from .telegram_auth import TelegramInitDataError, validate_init_data  # noqa: F401
+from .telegram_auth import (  # noqa: F401
+    TelegramInitDataError,
+    validate_init_data,
+)


### PR DESCRIPTION
🎯 **What:** Removed unused `START_PAYLOAD_*` variables from `stixmagic/__init__.py`. Re-formatted the trailing import to fix PEP 8 `E501` line length violation.
💡 **Why:** Cleans up the `stixmagic` namespace by not exposing variables that are not explicitly needed at the top-level. Improves maintainability and readability by reducing clutter in the module's exposed API. Also resolved a line length linting error to improve code health.
✅ **Verification:** Ran `TELEGRAM_BOT_TOKEN=dummy STIXMAGIC_API_KEY=supersecret poetry run python -m unittest discover tests` successfully (no new errors introduced). Also ran `flake8 stixmagic/__init__.py` to ensure adherence to formatting rules.
✨ **Result:** A cleaner initialization file for the `stixmagic` module, accurately exposing only the needed constants, and fully compliant with PEP 8 styling rules.

---
*PR created automatically by Jules for task [8425300779059902575](https://jules.google.com/task/8425300779059902575) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the `stixmagic` package’s re-exported symbols and import formatting; no runtime logic changes.
> 
> **Overview**
> Removes the `START_PAYLOAD_*` constants from `stixmagic/__init__.py` so they are no longer exposed as top-level re-exports from the package.
> 
> Reformats the `telegram_auth` import into a multiline form to satisfy line-length/PEP8 linting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da1757c9eda25f1e70c2fb6195025a7c98cefa4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->