### PR TITLE
🧹 Refactor build_pack for code health

### DIFF
--- a/pipeline/packager/__init__.py
+++ b/pipeline/packager/__init__.py
@@ -204,6 +204,81 @@ def validate_pack(
 
 # ── Build helper ──────────────────────────────────────────────
 
+
+def _resolve_assets(pack: PackDefinition, catalog: Any) -> list[Asset]:
+    if pack.included_assets:
+        return [
+            a for aid in pack.included_assets
+            if (a := catalog.get(aid)) is not None
+        ]
+    return catalog.all()
+
+def _resolve_presets(pack: PackDefinition) -> list[Any]:
+    from pipeline.motion_presets import get_preset, BUILTIN_PRESETS
+    if pack.included_motion_presets:
+        return [p for pid in pack.included_motion_presets if (p := get_preset(pid)) is not None]
+    return list(BUILTIN_PRESETS)
+
+def _build_entries(
+    pack: PackDefinition,
+    assets: list[Asset],
+    presets: list[Any],
+    renders_root: str
+) -> list[PackManifestEntry]:
+    _dir_map = {
+        "gif":          os.path.join(renders_root, "gif"),
+        "webp":         os.path.join(renders_root, "webp"),
+        "webm":         os.path.join(renders_root, "webm"),
+        "mov":          os.path.join(renders_root, "mov"),
+        "png_sequence": os.path.join(renders_root, "png_sequences"),
+        "thumbnail":    os.path.join(renders_root, "thumbnails"),
+    }
+    _ext_map = {
+        "gif": "gif", "webp": "webp", "webm": "webm",
+        "mov": "mov", "thumbnail": "png",
+    }
+
+    # ⚡ Bolt Optimization: Pre-compute formats and loop invariants
+    # Impact: Reduces O(Assets * Presets * Formats) dictionary lookups and path building
+    has_thumb = "thumbnail" in pack.export_formats
+    has_seq = "png_sequence" in pack.export_formats
+    thumb_dir = _dir_map.get("thumbnail")
+    seq_dir = _dir_map.get("png_sequence")
+
+    other_formats = [
+        (fmt, _ext_map.get(fmt, fmt), _dir_map[fmt])
+        for fmt in pack.export_formats
+        if fmt not in ("thumbnail", "png_sequence") and fmt in _dir_map
+    ]
+
+    entries = []
+    for asset in assets:
+        asset_id = asset.id
+        # Thumbnail only depends on the asset, not the preset
+        thumb_path = os.path.join(thumb_dir, f"{asset_id}_thumb.png") if has_thumb and thumb_dir else None
+
+        for preset in presets:
+            preset_id = preset.id
+            outputs: dict[str, str] = {}
+
+            if has_thumb and thumb_path:
+                outputs["thumbnail"] = thumb_path
+
+            if has_seq and seq_dir:
+                outputs["png_sequence"] = os.path.join(seq_dir, f"{asset_id}_{preset_id}_frames")
+
+            for fmt, ext, fdir in other_formats:
+                outputs[fmt] = os.path.join(fdir, f"{asset_id}_{preset_id}.{ext}")
+
+            entries.append(
+                PackManifestEntry(
+                    asset_id=asset_id,
+                    preset_id=preset_id,
+                    expected_outputs=outputs,
+                )
+            )
+    return entries
+
 def build_pack(
     pack: PackDefinition,
     catalog: Any,  # pipeline.metadata.AssetCatalog
@@ -241,80 +316,14 @@ def build_pack(
     PackValidationError
         When ``strict_validation=True`` and an invalid reference is found.
     """
-    from pipeline.motion_presets import get_preset, BUILTIN_PRESETS
-
     # Validate referenced assets and presets before building the manifest
     validate_pack(pack, catalog, strict=strict_validation)
 
-    # Resolve assets
-    if pack.included_assets:
-        assets: list[Asset] = [
-            a for aid in pack.included_assets
-            if (a := catalog.get(aid)) is not None
-        ]
-    else:
-        assets = catalog.all()
+    assets = _resolve_assets(pack, catalog)
+    presets = _resolve_presets(pack)
+    entries = _build_entries(pack, assets, presets, renders_root)
 
-    # Resolve presets
-    if pack.included_motion_presets:
-        presets = [p for pid in pack.included_motion_presets if (p := get_preset(pid)) is not None]
-    else:
-        presets = list(BUILTIN_PRESETS)
-
-    manifest = PackManifest(pack_id=pack.pack_id)
-
-    _dir_map = {
-        "gif":          os.path.join(renders_root, "gif"),
-        "webp":         os.path.join(renders_root, "webp"),
-        "webm":         os.path.join(renders_root, "webm"),
-        "mov":          os.path.join(renders_root, "mov"),
-        "png_sequence": os.path.join(renders_root, "png_sequences"),
-        "thumbnail":    os.path.join(renders_root, "thumbnails"),
-    }
-    _ext_map = {
-        "gif": "gif", "webp": "webp", "webm": "webm",
-        "mov": "mov", "thumbnail": "png",
-    }
-
-    # ⚡ Bolt Optimization: Pre-compute formats and loop invariants
-    # Impact: Reduces O(Assets * Presets * Formats) dictionary lookups and path building
-    has_thumb = "thumbnail" in pack.export_formats
-    has_seq = "png_sequence" in pack.export_formats
-    thumb_dir = _dir_map.get("thumbnail")
-    seq_dir = _dir_map.get("png_sequence")
-
-    other_formats = [
-        (fmt, _ext_map.get(fmt, fmt), _dir_map[fmt])
-        for fmt in pack.export_formats
-        if fmt not in ("thumbnail", "png_sequence") and fmt in _dir_map
-    ]
-
-    for asset in assets:
-        asset_id = asset.id
-        # Thumbnail only depends on the asset, not the preset
-        thumb_path = os.path.join(thumb_dir, f"{asset_id}_thumb.png") if has_thumb else None
-
-        for preset in presets:
-            preset_id = preset.id
-            outputs: dict[str, str] = {}
-
-            if has_thumb and thumb_path:
-                outputs["thumbnail"] = thumb_path
-
-            if has_seq and seq_dir:
-                outputs["png_sequence"] = os.path.join(seq_dir, f"{asset_id}_{preset_id}_frames")
-
-            for fmt, ext, fdir in other_formats:
-                outputs[fmt] = os.path.join(fdir, f"{asset_id}_{preset_id}.{ext}")
-
-            manifest.entries.append(
-                PackManifestEntry(
-                    asset_id=asset_id,
-                    preset_id=preset_id,
-                    expected_outputs=outputs,
-                )
-            )
-
+    manifest = PackManifest(pack_id=pack.pack_id, entries=entries)
     logger.info("build_pack: %s", manifest.summary())
     return manifest
 

--- a/tests/test_packager.py
+++ b/tests/test_packager.py
@@ -1,0 +1,52 @@
+import unittest
+from pipeline.packager import build_pack, PackDefinition, PackManifest, PackManifestEntry
+from pipeline.asset_model import Asset
+
+class MockCatalog:
+    def __init__(self, assets):
+        self._assets = {a.id: a for a in assets}
+
+    def get(self, aid):
+        return self._assets.get(aid)
+
+    def all(self):
+        return list(self._assets.values())
+
+class TestPackager(unittest.TestCase):
+    def test_build_pack(self):
+        assets = [
+            Asset(id="a1", name="A1", category="cat", source_format="png", source_path="p1"),
+            Asset(id="a2", name="A2", category="cat", source_format="png", source_path="p2")
+        ]
+        catalog = MockCatalog(assets)
+
+        pack = PackDefinition(
+            pack_id="test_pack",
+            title="Test Pack",
+            included_assets=["a1"],
+            export_formats=["gif", "thumbnail"],
+            included_motion_presets=["preset1"]
+        )
+
+        import pipeline.motion_presets
+
+        class MockPreset:
+            def __init__(self, pid):
+                self.id = pid
+
+        pipeline.motion_presets.get_preset = lambda pid: MockPreset(pid)
+        pipeline.motion_presets.BUILTIN_PRESETS = [MockPreset("builtin1")]
+        pipeline.motion_presets.PRESET_REGISTRY = {"preset1": MockPreset("preset1")}
+
+        manifest = build_pack(pack, catalog, strict_validation=False)
+        self.assertEqual(manifest.pack_id, "test_pack")
+        self.assertEqual(len(manifest.entries), 1)
+
+        entry = manifest.entries[0]
+        self.assertEqual(entry.asset_id, "a1")
+        self.assertEqual(entry.preset_id, "preset1")
+        self.assertTrue("thumbnail" in entry.expected_outputs)
+        self.assertTrue("gif" in entry.expected_outputs)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 What:
Refactored the complex `build_pack` function in `pipeline/packager/__init__.py` into smaller, focused helper functions: `_resolve_assets`, `_resolve_presets`, and `_build_entries`.

💡 Why:
The original function was over 110 lines long, making it hard to read, maintain, and unit test. Extracting the asset resolution, preset resolution, and entry generation logic into isolated helpers makes the code much cleaner and easier to reason about, while preserving the recent 'Bolt' performance optimizations (pre-computing invariants before the nested loops).

✅ Verification:
Compiled the updated file with `python3 -m py_compile pipeline/packager/__init__.py`. Created a new unit test suite `tests/test_packager.py` specifically asserting the logic of `build_pack`, which passes successfully. Ran the entire test suite via `unittest discover` to ensure no functionality regressions were introduced. Received a 'Correct' rating from the automated code review.

✨ Result:
Improved code readability, testability, and modularity for the asset packager, ensuring the function is now composed of easily testable, single-responsibility helpers without altering any existing behavior.

---
*PR created automatically by Jules for task [6230649624464498556](https://jules.google.com/task/6230649624464498556) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that primarily restructures `build_pack` and adds tests; only minor behavior change is extra guarding when computing thumbnail paths if directories are missing.
> 
> **Overview**
> Refactors `build_pack` by extracting asset resolution, preset resolution, and manifest entry generation into `_resolve_assets`, `_resolve_presets`, and `_build_entries`, while preserving the existing precomputed loop invariants.
> 
> Adds `tests/test_packager.py` to assert `build_pack` produces the expected `PackManifestEntry` outputs for a simple pack configuration (including `gif` and `thumbnail`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43d7eaa14ea8c4987017e9283bf4a42d893288d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->