### PR TITLE
🧪 Add tests for pipeline manifest generator

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,7 +1,0 @@
-Title: 🧪 Test validate_pack_title failure in create_title
-
-🎯 **What:** The `create_title` handler in `main.py` lacked a unit test verifying its behaviour when a pack title validation failed.
-
-📊 **Coverage:** A new test case `test_mocked_validate_pack_title_false` was added to `tests/test_main_forge_handlers.py`. It uses a mock to ensure that a title validation returning `False` correctly causes the handler to prompt the user again by returning the `WAITING_TITLE` state and sending the appropriate error message via Telegram.
-
-✨ **Result:** Enhanced test coverage for edge cases involving pack title validation during the pack creation flow.

--- a/tests/test_pipeline_manifest.py
+++ b/tests/test_pipeline_manifest.py
@@ -1,0 +1,186 @@
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from pipeline.manifest import generate_pipeline_manifest
+from pipeline.packager import PackManifest, PackManifestEntry
+
+
+class TestPipelineManifest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+
+        self.packs_dir = os.path.join(self.temp_dir.name, "packs")
+        os.makedirs(self.packs_dir)
+
+        self.output_path = os.path.join(self.temp_dir.name, "pipeline_manifest.json")
+        self.catalog_path = os.path.join(self.temp_dir.name, "catalog.json")
+
+        # Create a dummy catalog
+        dummy_catalog = [
+            {
+                "id": "asset1",
+                "name": "Asset One",
+                "category": "letter",
+                "source_format": "png",
+                "source_path": "src/asset1.png",
+                "export_targets": ["gif"]
+            }
+        ]
+        with open(self.catalog_path, "w") as f:
+            json.dump(dummy_catalog, f)
+
+    def test_missing_packs_dir(self):
+        """Test with a packs_dir that doesn't exist."""
+        result = generate_pipeline_manifest(
+            output_path=self.output_path,
+            packs_dir=os.path.join(self.temp_dir.name, "nonexistent"),
+            catalog_path=self.catalog_path
+        )
+        self.assertEqual(result["total_packs"], 0)
+        self.assertEqual(result["total_assets"], 0)
+        self.assertEqual(result["packs"], [])
+
+        # Verify file was written
+        self.assertTrue(os.path.exists(self.output_path))
+        with open(self.output_path) as f:
+            data = json.load(f)
+            self.assertEqual(data["total_packs"], 0)
+
+    @patch("pipeline.packager.build_pack")
+    def test_successful_manifest_generation(self, mock_build_pack):
+        """Test successful generation with valid packs."""
+        # Setup fake pack directory and file
+        pack_dir = os.path.join(self.packs_dir, "test_pack")
+        os.makedirs(pack_dir)
+
+        pack_json = {
+            "pack_id": "test_pack",
+            "title": "Test Pack",
+            "included_assets": ["asset1"]
+        }
+        with open(os.path.join(pack_dir, "pack.json"), "w") as f:
+            json.dump(pack_json, f)
+
+        # Mock build_pack
+        mock_manifest = PackManifest(
+            pack_id="test_pack",
+            entries=[
+                PackManifestEntry(
+                    asset_id="asset1",
+                    preset_id="preset1",
+                    expected_outputs={
+                        "gif": "renders/gif/asset1_preset1.gif",
+                        "thumbnail": "renders/thumbnails/asset1_thumb.png"
+                    }
+                )
+            ]
+        )
+        mock_build_pack.return_value = mock_manifest
+
+        result = generate_pipeline_manifest(
+            output_path=self.output_path,
+            packs_dir=self.packs_dir,
+            catalog_path=self.catalog_path
+        )
+
+        self.assertEqual(result["total_packs"], 1)
+        self.assertEqual(result["total_assets"], 1)
+        self.assertEqual(len(result["packs"]), 1)
+
+        pack_data = result["packs"][0]
+        self.assertEqual(pack_data["pack_id"], "test_pack")
+        self.assertEqual(len(pack_data["entries"]), 1)
+
+        entry = pack_data["entries"][0]
+        self.assertEqual(entry["asset_id"], "asset1")
+        self.assertEqual(entry["thumbnail"], "renders/thumbnails/asset1_thumb.png")
+        self.assertEqual(entry["outputs"]["gif"], "renders/gif/asset1_preset1.gif")
+
+        # Verify file was written correctly
+        with open(self.output_path) as f:
+            written_data = json.load(f)
+            self.assertEqual(written_data["total_packs"], 1)
+
+    def test_invalid_pack_json(self):
+        """Test handling of an invalid pack.json file."""
+        pack_dir = os.path.join(self.packs_dir, "bad_pack")
+        os.makedirs(pack_dir)
+
+        # Write invalid JSON
+        with open(os.path.join(pack_dir, "pack.json"), "w") as f:
+            f.write("{ invalid json")
+
+        # Write a valid JSON for another pack
+        good_pack_dir = os.path.join(self.packs_dir, "good_pack")
+        os.makedirs(good_pack_dir)
+        with open(os.path.join(good_pack_dir, "pack.json"), "w") as f:
+            json.dump({
+                "pack_id": "good_pack",
+                "title": "Good Pack",
+                "included_assets": []
+            }, f)
+
+        with patch("pipeline.packager.build_pack") as mock_build_pack:
+            mock_build_pack.return_value = PackManifest(pack_id="good_pack", entries=[])
+
+            with patch("pipeline.manifest.logger") as mock_logger:
+                result = generate_pipeline_manifest(
+                    output_path=self.output_path,
+                    packs_dir=self.packs_dir,
+                    catalog_path=self.catalog_path
+                )
+
+                # Should have 1 pack (the good one), the bad one should be skipped
+                self.assertEqual(result["total_packs"], 1)
+
+                # Verify logger.error was called for the bad pack
+                mock_logger.error.assert_any_call("Skipping %s – failed to load: %s", os.path.join(pack_dir, "pack.json"), unittest.mock.ANY)
+
+    @patch("pipeline.packager.build_pack")
+    def test_build_pack_failure(self, mock_build_pack):
+        """Test handling when build_pack raises an exception."""
+        pack_dir = os.path.join(self.packs_dir, "fail_pack")
+        os.makedirs(pack_dir)
+        with open(os.path.join(pack_dir, "pack.json"), "w") as f:
+            json.dump({
+                "pack_id": "fail_pack",
+                "title": "Fail Pack",
+            }, f)
+
+        mock_build_pack.side_effect = Exception("Simulated build_pack error")
+
+        with patch("pipeline.manifest.logger") as mock_logger:
+            result = generate_pipeline_manifest(
+                output_path=self.output_path,
+                packs_dir=self.packs_dir,
+                catalog_path=self.catalog_path
+            )
+
+            # Pack should be skipped
+            self.assertEqual(result["total_packs"], 0)
+            mock_logger.error.assert_any_call("Skipping pack %r – build_pack failed: %s", "fail_pack", unittest.mock.ANY)
+
+    def test_output_write_failure(self):
+        """Test that function handles failure to write the output file."""
+        # Create a bad output path (directory doesn't exist)
+        bad_output_path = os.path.join(self.temp_dir.name, "does_not_exist", "out.json")
+
+        with patch("pipeline.manifest.logger") as mock_logger:
+            result = generate_pipeline_manifest(
+                output_path=bad_output_path,
+                packs_dir=self.packs_dir,
+                catalog_path=self.catalog_path
+            )
+
+            # Dictionary should still be returned
+            self.assertEqual(result["total_packs"], 0)
+
+            # Logger should record the error
+            mock_logger.error.assert_called_with("Failed to write manifest to %s: %s", bad_output_path, unittest.mock.ANY)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `pipeline/manifest.py` file, which is responsible for discovering `pack.json` files and generating the global `pipeline_manifest.json`, had no unit tests. This PR introduces `tests/test_pipeline_manifest.py` to cover its core logic.

📊 **Coverage:** What scenarios are now tested
- **Successful generation**: Verifies that the correct dictionary schema is returned and the correct output file is written when given valid pack data.
- **Missing/Empty directory**: Ensures the function handles a non-existent or empty packs directory gracefully (returning 0 packs).
- **Invalid JSON files**: Confirms that corrupted `pack.json` files are safely skipped with an error log without interrupting the generation of other packs.
- **Build failures**: Validates that if a specific pack fails to build (e.g., missing dependencies in `build_pack`), it is correctly logged and skipped.
- **Write failures**: Checks that if the function cannot write the output JSON file, it logs an error but still safely returns the generated manifest dictionary.

✨ **Result:** The improvement in test coverage
The critical `generate_pipeline_manifest` logic is now fully tested, making the data model more resilient against regressions when the pack logic or output schema is modified in the future.

---
*PR created automatically by Jules for task [17255654136356531916](https://jules.google.com/task/17255654136356531916) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are test-only and do not modify runtime manifest generation logic.
> 
> **Overview**
> Adds a new `tests/test_pipeline_manifest.py` suite covering `generate_pipeline_manifest`, including *successful generation* (mocking `build_pack`) and error-path handling for *missing packs dir*, *invalid `pack.json`*, *`build_pack` exceptions*, and *output write failures* (verifying logging and that a manifest dict is still returned).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bed4d1615367249b06ea0628a6b3f67d134ef0a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->