### PR TITLE
🧪 [testing improvement] Add tests for GifExporter

### DIFF
--- a/tests/test_gif_exporter.py
+++ b/tests/test_gif_exporter.py
@@ -1,0 +1,64 @@
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from pipeline.asset_model.asset import Asset
+from pipeline.motion_presets.preset import MotionPreset
+from pipeline.exporters.gif_exporter import GifExporter
+
+
+class TestGifExporter(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.exporter = GifExporter(renders_dir=self.temp_dir)
+        self.asset = Asset(
+            id="test_asset",
+            name="Test Asset",
+            category="letter",
+            theme="neon",
+            source_format="png",
+            source_path="test.png",
+            width=100,
+            height=100
+        )
+        self.preset = MotionPreset(
+            id="test_preset",
+            name="Test Preset"
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_export_success(self):
+        result = self.exporter.export(self.asset, self.preset)
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.format, "gif")
+        expected_filename = f"{self.asset.id}_{self.preset.id}.gif"
+        self.assertTrue(result.path.endswith(expected_filename))
+        self.assertTrue(os.path.exists(result.path))
+
+        with open(result.path, "rb") as fh:
+            data = fh.read()
+
+        expected_bytes = self.exporter._render_frames(self.asset, self.preset)
+        self.assertEqual(data, expected_bytes)
+        self.assertEqual(result.size_bytes, len(expected_bytes))
+
+    def test_export_failure(self):
+        with patch.object(self.exporter, '_render_frames', side_effect=Exception("Test Error")):
+            result = self.exporter.export(self.asset, self.preset)
+
+            self.assertFalse(result.success)
+            self.assertEqual(result.format, "gif")
+            self.assertIn("Test Error", result.message)
+
+    def test_render_frames_returns_minimal_gif(self):
+        frames = self.exporter._render_frames(self.asset, self.preset)
+        self.assertTrue(frames.startswith(b"GIF89a"))
+        self.assertTrue(frames.endswith(b";"))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 What: The testing gap addressed
This adds missing unit tests for pipeline/exporters/gif_exporter.py. The exporter is currently just a placeholder that writes a minimal GIF file.

📊 Coverage: What scenarios are now tested
The tests now cover:
- test_export_success: Verified that calling export correctly creates a file, sets the result state to success, and returns the expected result structure and content.
- test_export_failure: Verified that exceptions thrown during the _render_frames method are correctly caught and returned inside the failed ExportResult object without crashing the application.
- test_render_frames_returns_minimal_gif: Verified that the placeholder stub actually returns minimal valid GIF89a header bytes.

✨ Result: The improvement in test coverage
GifExporter now has 100% test coverage of its behavior, allowing the developers to comfortably modify the implementation once the real Pillow rendering engine is attached, ensuring that no regressions break its pipeline interface expectations.

---
*PR created automatically by Jules for task [13068098804167665561](https://jules.google.com/task/13068098804167665561) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that doesn’t alter production logic, but it does lock in current `GifExporter.export`/`_render_frames` placeholder behavior.
> 
> **Overview**
> Adds a new `tests/test_gif_exporter.py` suite covering `GifExporter`.
> 
> The tests assert that `export()` writes a `.gif` file with the expected name/content and reports correct `ExportResult` fields, and that exceptions from `_render_frames` are converted into a failed `ExportResult` message. They also pin the placeholder `_render_frames()` output to a minimally valid `GIF89a` byte sequence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03e07354197b96fb78f905f4e84daee978b6f90c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->