### PR TITLE
🧹 [Code Health] Remove unused mock import in tests

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -38,3 +38,6 @@
 ## 2026-05-13 - Loop Invariant Code Motion and Lookup Optimization
 **Learning:** Found that `pipeline/packager/__init__.py::build_pack` had an O(Assets * Presets * Formats) nested loop that repeatedly performed identical dictionary lookups and conditional checks (like checking if the format was 'thumbnail') which were invariant for a given asset or the entire execution. This resulted in redundant work and slower execution.
 **Action:** Extracted loop invariants and pre-computed static values (e.g. format tuples, constant thumbnail paths) outside the inner loops. This minimizes repeated dictionary accesses and condition evaluations, yielding an ~23% performance improvement in manifest generation.
+## 2024-05-14 - Removed unused import from tests
+**Learning:** Removing unused imports like `call` from the `unittest.mock` module keeps code clean and test files concise.
+**Action:** Use linters or check manually to identify and prune unused imports during regular code health tasks.

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -20,7 +20,7 @@ import sys
 import time
 import tempfile
 import unittest
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import urlencode
 
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `call` import from `unittest.mock` in `tests/test_api_helpers.py`.
💡 **Why:** Having unused imports clutters the test file and might confuse maintainers.
✅ **Verification:** Ran the full test suite (`python -m unittest tests/test_api_helpers.py`) to ensure everything still passes.
✨ **Result:** A cleaner test file and reduced chance of lint warnings.

---
*PR created automatically by Jules for task [9000773938808001834](https://jules.google.com/task/9000773938808001834) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk code-health change limited to test imports and internal documentation; no runtime logic is affected.
> 
> **Overview**
> Removes the unused `call` import from `unittest.mock` in `tests/test_api_helpers.py` to reduce test-file clutter and potential lint warnings.
> 
> Adds a short entry to `.jules/bolt.md` documenting the code-health cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34fa01b73d88ff889764e4e8b6fb2f50f01a0c96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->