### PR TITLE
🧪 [testing improvement] Add missing unit tests for MotionPreset

### DIFF
--- a/tests/test_motion_presets_preset.py
+++ b/tests/test_motion_presets_preset.py
@@ -1,0 +1,74 @@
+import unittest
+from pipeline.motion_presets.preset import MotionPreset
+
+class TestMotionPreset(unittest.TestCase):
+    def test_initialization_defaults(self):
+        preset = MotionPreset(id="test_id", name="Test Name")
+        self.assertEqual(preset.id, "test_id")
+        self.assertEqual(preset.name, "Test Name")
+        self.assertTrue(preset.loopable)
+        self.assertEqual(preset.duration_ms, 1000)
+        self.assertTrue(preset.alpha_safe)
+        self.assertTrue(preset.overlay_safe)
+        self.assertTrue(preset.sticker_safe)
+        self.assertEqual(preset.recommended_categories, [])
+        self.assertEqual(preset.parameter_schema, {})
+        self.assertEqual(preset.description, "")
+
+    def test_is_recommended_for(self):
+        # Empty recommended_categories
+        preset1 = MotionPreset(id="test1", name="Test 1")
+        self.assertTrue(preset1.is_recommended_for("any_category"))
+
+        # Specific recommended_categories
+        preset2 = MotionPreset(id="test2", name="Test 2", recommended_categories=["cat1", "cat2"])
+        self.assertTrue(preset2.is_recommended_for("cat1"))
+        self.assertTrue(preset2.is_recommended_for("cat2"))
+        self.assertFalse(preset2.is_recommended_for("cat3"))
+
+    def test_to_dict_and_from_dict(self):
+        original = MotionPreset(
+            id="test_id",
+            name="Test Name",
+            loopable=False,
+            duration_ms=500,
+            alpha_safe=False,
+            overlay_safe=False,
+            sticker_safe=False,
+            recommended_categories=["cat1"],
+            parameter_schema={"param1": "val1"},
+            description="Test Description"
+        )
+        data = original.to_dict()
+        expected_data = {
+            "id": "test_id",
+            "name": "Test Name",
+            "loopable": False,
+            "duration_ms": 500,
+            "alpha_safe": False,
+            "overlay_safe": False,
+            "sticker_safe": False,
+            "recommended_categories": ["cat1"],
+            "parameter_schema": {"param1": "val1"},
+            "description": "Test Description"
+        }
+        self.assertEqual(data, expected_data)
+
+        restored = MotionPreset.from_dict(data)
+        self.assertEqual(restored.id, original.id)
+        self.assertEqual(restored.name, original.name)
+        self.assertEqual(restored.loopable, original.loopable)
+        self.assertEqual(restored.duration_ms, original.duration_ms)
+        self.assertEqual(restored.alpha_safe, original.alpha_safe)
+        self.assertEqual(restored.overlay_safe, original.overlay_safe)
+        self.assertEqual(restored.sticker_safe, original.sticker_safe)
+        self.assertEqual(restored.recommended_categories, original.recommended_categories)
+        self.assertEqual(restored.parameter_schema, original.parameter_schema)
+        self.assertEqual(restored.description, original.description)
+
+    def test_repr(self):
+        preset = MotionPreset(id="test_id", name="Test Name", duration_ms=1500, loopable=False)
+        self.assertEqual(repr(preset), "<MotionPreset id='test_id' duration_ms=1500 loopable=False>")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** Created missing tests for the MotionPreset dataclass, ensuring that default values and core logic like is_recommended_for, to_dict, and from_dict are well-covered.
📊 **Coverage:** Added test cases for initialization, serialization (to_dict, from_dict), category recommendation matching (is_recommended_for), and representations (__repr__).
✨ **Result:** Improved test coverage and reliability for preset models during pipeline operations.

---
*PR created automatically by Jules for task [11778878751080595630](https://jules.google.com/task/11778878751080595630) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds only unit tests and does not change runtime behavior. Main risk is minor brittleness if `MotionPreset` defaults/`__repr__` formatting change.
> 
> **Overview**
> Adds a new `unittest` suite for `MotionPreset` validating **default field values**, `is_recommended_for` behavior (empty vs explicit `recommended_categories`), and round-trip correctness of `to_dict`/`from_dict`.
> 
> Also asserts a stable string format for `__repr__`, increasing coverage but potentially making tests sensitive to representation changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f5ba981abdc4d71c9a43252ed4dbeee75d280b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->