### PR TITLE
🧹 Refactor build_pack function for improved readability and modularity

### DIFF
--- a/pipeline/packager/__init__.py
+++ b/pipeline/packager/__init__.py
@@ -202,7 +202,84 @@ def validate_pack(
     return errors
 
 
-# ── Build helper ──────────────────────────────────────────────
+# ── Build helpers ─────────────────────────────────────────────
+
+def _resolve_assets(pack: PackDefinition, catalog: Any) -> list[Asset]:
+    """Resolve the list of assets to include in the pack."""
+    if pack.included_assets:
+        return [
+            a for aid in pack.included_assets
+            if (a := catalog.get(aid)) is not None
+        ]
+    return catalog.all()
+
+def _resolve_presets(pack: PackDefinition) -> list[Any]:
+    """Resolve the list of motion presets to include in the pack."""
+    from pipeline.motion_presets import get_preset, BUILTIN_PRESETS
+    if pack.included_motion_presets:
+        return [p for pid in pack.included_motion_presets if (p := get_preset(pid)) is not None]
+    return list(BUILTIN_PRESETS)
+
+def _build_entries(
+    pack: PackDefinition,
+    assets: list[Asset],
+    presets: list[Any],
+    renders_root: str
+) -> list[PackManifestEntry]:
+    """Build the expected output manifest entries."""
+    _dir_map = {
+        "gif":          os.path.join(renders_root, "gif"),
+        "webp":         os.path.join(renders_root, "webp"),
+        "webm":         os.path.join(renders_root, "webm"),
+        "mov":          os.path.join(renders_root, "mov"),
+        "png_sequence": os.path.join(renders_root, "png_sequences"),
+        "thumbnail":    os.path.join(renders_root, "thumbnails"),
+    }
+    _ext_map = {
+        "gif": "gif", "webp": "webp", "webm": "webm",
+        "mov": "mov", "thumbnail": "png",
+    }
+
+    # ⚡ Bolt Optimization: Pre-compute formats and loop invariants
+    # Impact: Reduces O(Assets * Presets * Formats) dictionary lookups and path building
+    has_thumb = "thumbnail" in pack.export_formats
+    has_seq = "png_sequence" in pack.export_formats
+    thumb_dir = _dir_map.get("thumbnail")
+    seq_dir = _dir_map.get("png_sequence")
+
+    other_formats = [
+        (fmt, _ext_map.get(fmt, fmt), _dir_map[fmt])
+        for fmt in pack.export_formats
+        if fmt not in ("thumbnail", "png_sequence") and fmt in _dir_map
+    ]
+
+    entries = []
+    for asset in assets:
+        asset_id = asset.id
+        # Thumbnail only depends on the asset, not the preset
+        thumb_path = os.path.join(thumb_dir, f"{asset_id}_thumb.png") if has_thumb else None
+
+        for preset in presets:
+            preset_id = preset.id
+            outputs: dict[str, str] = {}
+
+            if has_thumb and thumb_path:
+                outputs["thumbnail"] = thumb_path
+
+            if has_seq and seq_dir:
+                outputs["png_sequence"] = os.path.join(seq_dir, f"{asset_id}_{preset_id}_frames")
+
+            for fmt, ext, fdir in other_formats:
+                outputs[fmt] = os.path.join(fdir, f"{asset_id}_{preset_id}.{ext}")
+
+            entries.append(
+                PackManifestEntry(
+                    asset_id=asset_id,
+                    preset_id=preset_id,
+                    expected_outputs=outputs,
+                )
+            )
+    return entries
 
 def build_pack(
     pack: PackDefinition,
@@ -241,79 +318,18 @@ def build_pack(
     PackValidationError
         When ``strict_validation=True`` and an invalid reference is found.
     """
-    from pipeline.motion_presets import get_preset, BUILTIN_PRESETS
 
     # Validate referenced assets and presets before building the manifest
     validate_pack(pack, catalog, strict=strict_validation)
 
     # Resolve assets
-    if pack.included_assets:
-        assets: list[Asset] = [
-            a for aid in pack.included_assets
-            if (a := catalog.get(aid)) is not None
-        ]
-    else:
-        assets = catalog.all()
+    assets = _resolve_assets(pack, catalog)
 
     # Resolve presets
-    if pack.included_motion_presets:
-        presets = [p for pid in pack.included_motion_presets if (p := get_preset(pid)) is not None]
-    else:
-        presets = list(BUILTIN_PRESETS)
+    presets = _resolve_presets(pack)
 
     manifest = PackManifest(pack_id=pack.pack_id)
-
-    _dir_map = {
-        "gif":          os.path.join(renders_root, "gif"),
-        "webp":         os.path.join(renders_root, "webp"),
-        "webm":         os.path.join(renders_root, "webm"),
-        "mov":          os.path.join(renders_root, "mov"),
-        "png_sequence": os.path.join(renders_root, "png_sequences"),
-        "thumbnail":    os.path.join(renders_root, "thumbnails"),
-    }
-    _ext_map = {
-        "gif": "gif", "webp": "webp", "webm": "webm",
-        "mov": "mov", "thumbnail": "png",
-    }
-
-    # ⚡ Bolt Optimization: Pre-compute formats and loop invariants
-    # Impact: Reduces O(Assets * Presets * Formats) dictionary lookups and path building
-    has_thumb = "thumbnail" in pack.export_formats
-    has_seq = "png_sequence" in pack.export_formats
-    thumb_dir = _dir_map.get("thumbnail")
-    seq_dir = _dir_map.get("png_sequence")
-
-    other_formats = [
-        (fmt, _ext_map.get(fmt, fmt), _dir_map[fmt])
-        for fmt in pack.export_formats
-        if fmt not in ("thumbnail", "png_sequence") and fmt in _dir_map
-    ]
-
-    for asset in assets:
-        asset_id = asset.id
-        # Thumbnail only depends on the asset, not the preset
-        thumb_path = os.path.join(thumb_dir, f"{asset_id}_thumb.png") if has_thumb else None
-
-        for preset in presets:
-            preset_id = preset.id
-            outputs: dict[str, str] = {}
-
-            if has_thumb and thumb_path:
-                outputs["thumbnail"] = thumb_path
-
-            if has_seq and seq_dir:
-                outputs["png_sequence"] = os.path.join(seq_dir, f"{asset_id}_{preset_id}_frames")
-
-            for fmt, ext, fdir in other_formats:
-                outputs[fmt] = os.path.join(fdir, f"{asset_id}_{preset_id}.{ext}")
-
-            manifest.entries.append(
-                PackManifestEntry(
-                    asset_id=asset_id,
-                    preset_id=preset_id,
-                    expected_outputs=outputs,
-                )
-            )
+    manifest.entries = _build_entries(pack, assets, presets, renders_root)
 
     logger.info("build_pack: %s", manifest.summary())
     return manifest


### PR DESCRIPTION
🎯 **What:** Extracted the complex logic in `pipeline/packager/__init__.py:build_pack` into smaller helper functions (`_resolve_assets`, `_resolve_presets`, and `_build_entries`).

💡 **Why:** The `build_pack` function was over 110 lines long and quite dense, making it harder to read and maintain. By splitting it into specialized helpers, we improve separation of concerns, modularity, and testability. The main function now serves as a clean coordinator.

✅ **Verification:** Ran the full test suite and packager-specific tests to confirm no regressions were introduced. The logic and output behavior are exactly preserved.

✨ **Result:** Improved code health and maintainability of the pack generation pipeline without changing external behavior.

---
*PR created automatically by Jules for task [6230649624464497649](https://jules.google.com/task/6230649624464497649) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor focused on readability/modularity; behavior should remain the same but could regress if helper extraction subtly changes asset/preset filtering or output path generation.
> 
> **Overview**
> Refactors `pipeline/packager/__init__.py` by splitting the previously monolithic `build_pack` into `_resolve_assets`, `_resolve_presets`, and `_build_entries`, making `build_pack` a coordinator that validates, resolves inputs, and assigns `manifest.entries`.
> 
> The manifest entry generation logic (expected output paths across formats, including thumbnails and PNG sequences) is moved into `_build_entries` with precomputed loop invariants, intended to keep behavior the same while improving readability and maintainability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6451d707108466f8c8151feda12d65e98416ac4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->