### PR TITLE
🧪 [testing improvement] Add tests for main.py navigation handlers

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,7 +1,14 @@
-Title: 🧪 Test validate_pack_title failure in create_title
+🧪 [testing improvement] Add tests for main.py navigation handlers
 
-🎯 **What:** The `create_title` handler in `main.py` lacked a unit test verifying its behaviour when a pack title validation failed.
+🎯 **What:**
+The `send_menu` and `nav_callback` functions in `main.py` lacked test coverage. These functions are critical for routing and rendering UI state transitions (like inline keyboards and text menus) via the Telegram Bot API. Due to their tight coupling with the API, they were difficult to unit test and thus overlooked.
 
-📊 **Coverage:** A new test case `test_mocked_validate_pack_title_false` was added to `tests/test_main_forge_handlers.py`. It uses a mock to ensure that a title validation returning `False` correctly causes the handler to prompt the user again by returning the `WAITING_TITLE` state and sending the appropriate error message via Telegram.
+📊 **Coverage:**
+Created `tests/test_main_nav.py` to test the missing functionalities using `unittest.IsolatedAsyncioTestCase` and `unittest.mock.patch`. The tests provide coverage for:
+- Routing a callback query through `nav_callback` to `send_menu`
+- Properly addressing callback query requests with `answer()`
+- Editing the callback query message text, ignoring benign "Message is not modified" Telegram `BadRequest` errors but properly raising others
+- Directly answering standalone messages by creating a new reply
 
-✨ **Result:** Enhanced test coverage for edge cases involving pack title validation during the pack creation flow.
+✨ **Result:**
+Significant improvement in test coverage for core navigation logic within `main.py`. The new isolated async tests handle API mocked dependencies securely without introducing cross-test pollution.

--- a/tests/test_main_nav.py
+++ b/tests/test_main_nav.py
@@ -1,0 +1,158 @@
+import asyncio
+import sys
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+def _make_stub(name):
+    mod = MagicMock()
+    mod.__name__ = name
+    return mod
+
+STUBS = {
+    "telegram": _make_stub("telegram"),
+    "telegram.ext": _make_stub("telegram.ext"),
+    "telegram.error": _make_stub("telegram.error"),
+    "PIL": _make_stub("PIL"),
+    "PIL.Image": _make_stub("PIL.Image"),
+    "PIL.ImageOps": _make_stub("PIL.ImageOps"),
+    "dotenv": _make_stub("dotenv"),
+}
+
+class StubMock:
+    def __init__(self, *args, **kwargs):
+        if args and isinstance(args[0], list):
+            self.inline_keyboard = args[0]
+        if "inline_keyboard" in kwargs:
+            self.inline_keyboard = kwargs["inline_keyboard"]
+        if "callback_data" in kwargs:
+            self.callback_data = kwargs["callback_data"]
+    DEFAULT_TYPE = MagicMock()
+
+for cls in ["InputSticker", "InlineKeyboardButton", "InlineKeyboardMarkup",
+            "InlineQueryResultArticle", "InputTextMessageContent",
+            "MenuButtonWebApp", "Update", "WebAppInfo"]:
+    setattr(STUBS["telegram"], cls, StubMock)
+
+for cls in ["Application", "CallbackQueryHandler", "CommandHandler",
+            "ContextTypes", "ConversationHandler", "InlineQueryHandler",
+            "MessageHandler"]:
+    setattr(STUBS["telegram.ext"], cls, StubMock)
+
+STUBS["telegram.ext"].ConversationHandler.END = -1
+STUBS["telegram.ext"].filters = MagicMock()
+
+class BadRequest(Exception):
+    pass
+STUBS["telegram.error"].BadRequest = BadRequest
+
+class TestMainNav(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.modules_patcher = patch.dict('sys.modules', STUBS)
+        self.modules_patcher.start()
+
+        self.local_patcher = patch.dict('sys.modules', {
+            'config.runtime': _make_stub('config.runtime'),
+            'infra.db': _make_stub('infra.db'),
+            'core.engine': _make_stub('core.engine'),
+            'domain.media': _make_stub('domain.media'),
+            'src.stickers.media': _make_stub('src.stickers.media'),
+            'stixmagic.settings': _make_stub('stixmagic.settings'),
+            'menus': _make_stub('menus'),
+            'packs.db': _make_stub('packs.db'),
+            'moderation.guard': _make_stub('moderation.guard'),
+            'loaders': _make_stub('loaders'),
+            'platforms.telegram': _make_stub('platforms.telegram')
+        })
+        self.local_patcher.start()
+
+        sys.modules['config.runtime'].get_settings = MagicMock(return_value=MagicMock())
+        sys.modules['config.runtime'].ConfigError = Exception
+        sys.modules['infra.db'].init_db = MagicMock()
+
+        import main
+        self.main = main
+
+    def tearDown(self):
+        self.modules_patcher.stop()
+        self.local_patcher.stop()
+
+    @patch('main.get_menu_text')
+    @patch('main.build_keyboard')
+    async def test_send_menu_callback_query(self, mock_build_keyboard, mock_get_menu_text):
+        mock_get_menu_text.return_value = "Test Menu"
+        mock_build_keyboard.return_value = MagicMock()
+
+        update = MagicMock()
+        update.callback_query = AsyncMock()
+        update.message = None
+
+        await self.main.send_menu(update, 'home')
+
+        update.callback_query.answer.assert_called_once()
+        update.callback_query.edit_message_text.assert_called_once_with(
+            "Test Menu", reply_markup=mock_build_keyboard.return_value, parse_mode="HTML", disable_web_page_preview=True
+        )
+
+    @patch('main.get_menu_text')
+    @patch('main.build_keyboard')
+    async def test_send_menu_callback_query_message_not_modified(self, mock_build_keyboard, mock_get_menu_text):
+        mock_get_menu_text.return_value = "Test Menu"
+        mock_build_keyboard.return_value = MagicMock()
+
+        update = MagicMock()
+        update.callback_query = AsyncMock()
+        update.callback_query.edit_message_text.side_effect = BadRequest("Message is not modified")
+        update.message = None
+
+        # Should not raise exception
+        await self.main.send_menu(update, 'home')
+
+        update.callback_query.answer.assert_called_once()
+        update.callback_query.edit_message_text.assert_called_once()
+
+    @patch('main.get_menu_text')
+    @patch('main.build_keyboard')
+    async def test_send_menu_callback_query_other_error(self, mock_build_keyboard, mock_get_menu_text):
+        mock_get_menu_text.return_value = "Test Menu"
+        mock_build_keyboard.return_value = MagicMock()
+
+        update = MagicMock()
+        update.callback_query = AsyncMock()
+        update.callback_query.edit_message_text.side_effect = BadRequest("Other error")
+        update.message = None
+
+        with self.assertRaises(BadRequest):
+            await self.main.send_menu(update, 'home')
+
+        update.callback_query.answer.assert_called_once()
+        update.callback_query.edit_message_text.assert_called_once()
+
+    @patch('main.get_menu_text')
+    @patch('main.build_keyboard')
+    async def test_send_menu_message(self, mock_build_keyboard, mock_get_menu_text):
+        mock_get_menu_text.return_value = "Test Menu"
+        mock_build_keyboard.return_value = MagicMock()
+
+        update = MagicMock()
+        update.callback_query = None
+        update.message = AsyncMock()
+
+        await self.main.send_menu(update, 'home')
+
+        update.message.reply_text.assert_called_once_with(
+            "Test Menu", reply_markup=mock_build_keyboard.return_value, parse_mode="HTML", disable_web_page_preview=True
+        )
+
+    @patch('main.send_menu')
+    async def test_nav_callback(self, mock_send_menu):
+        update = MagicMock()
+        update.callback_query = MagicMock()
+        update.callback_query.data = "nav:home"
+        context = MagicMock()
+
+        await self.main.nav_callback(update, context)
+
+        mock_send_menu.assert_called_once_with(update, "home")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🧪 [testing improvement] Add tests for main.py navigation handlers

🎯 **What:** 
The `send_menu` and `nav_callback` functions in `main.py` lacked test coverage. These functions are critical for routing and rendering UI state transitions (like inline keyboards and text menus) via the Telegram Bot API. Due to their tight coupling with the API, they were difficult to unit test and thus overlooked.

📊 **Coverage:** 
Created `tests/test_main_nav.py` to test the missing functionalities using `unittest.IsolatedAsyncioTestCase` and `unittest.mock.patch`. The tests provide coverage for:
- Routing a callback query through `nav_callback` to `send_menu`
- Properly addressing callback query requests with `answer()`
- Editing the callback query message text, ignoring benign "Message is not modified" Telegram `BadRequest` errors but properly raising others
- Directly answering standalone messages by creating a new reply

✨ **Result:** 
Significant improvement in test coverage for core navigation logic within `main.py`. The new isolated async tests handle API mocked dependencies securely without introducing cross-test pollution.

---
*PR created automatically by Jules for task [17680322038235943693](https://jules.google.com/task/17680322038235943693) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds only unit tests and documentation; no production code paths are modified, so runtime risk is minimal.
> 
> **Overview**
> Adds a new `tests/test_main_nav.py` suite that stubs Telegram/PIL modules and uses isolated async mocks to cover `send_menu` and `nav_callback`, including callback-query answering, message edits, and the special-case ignore of Telegram `BadRequest("Message is not modified")`.
> 
> Updates `pr_description.md` to reflect the new navigation test coverage focus.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fe522577ce3723b0acd6127ab6f7107c7ef1d69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->