### PR TITLE
🧹 [Code Health] Simplify export_all orchestrator

### DIFF
--- a/pipeline/exporters/__init__.py
+++ b/pipeline/exporters/__init__.py
@@ -302,6 +302,43 @@ def export_thumbnail(
 
 # ── Aggregate exporter ────────────────────────────────────────
 
+def _get_dispatch(renders_root: str) -> dict:
+    return {
+        "gif":          (export_gif,          os.path.join(renders_root, "gif")),
+        "webp":         (export_animated_webp, os.path.join(renders_root, "webp")),
+        "webm":         (export_webm,          os.path.join(renders_root, "webm")),
+        "mov":          (export_mov,           os.path.join(renders_root, "mov")),
+        "png_sequence": (export_png_sequence,  os.path.join(renders_root, "png_sequences")),
+    }
+
+
+def _run_exporter(
+    fmt: str,
+    source_path: str,
+    preset: MotionPreset,
+    renders_root: str,
+    dispatch: dict,
+) -> tuple[str | None, str | None]:
+    """Run a single exporter and return (path, error_message)."""
+    if fmt == "thumbnail":
+        path = export_thumbnail(source_path, os.path.join(renders_root, "thumbnails"))
+        if not path:
+            return None, "thumbnail export failed"
+        return path, None
+
+    if fmt not in dispatch:
+        return None, f"unknown format: {fmt!r}"
+
+    exporter_fn, out_dir = dispatch[fmt]
+    try:
+        path = exporter_fn(source_path, preset, out_dir)
+        if not path:
+            return None, f"{fmt} export returned None"
+        return path, None
+    except Exception as exc:
+        return None, f"{fmt} export raised: {exc}"
+
+
 def export_all(
     asset_id: str,
     source_path: str,
@@ -337,42 +374,17 @@ def export_all(
         formats = ["gif", "webp", "webm", "mov", "png_sequence", "thumbnail"]
 
     result = ExportResult(asset_id=asset_id, preset_id=preset.id)
-
-    _dispatch = {
-        "gif":          (export_gif,          os.path.join(renders_root, "gif")),
-        "webp":         (export_animated_webp, os.path.join(renders_root, "webp")),
-        "webm":         (export_webm,          os.path.join(renders_root, "webm")),
-        "mov":          (export_mov,           os.path.join(renders_root, "mov")),
-        "png_sequence": (export_png_sequence,  os.path.join(renders_root, "png_sequences")),
-    }
+    dispatch = _get_dispatch(renders_root)
 
     for fmt in formats:
-        if fmt == "thumbnail":
-            path = export_thumbnail(source_path, os.path.join(renders_root, "thumbnails"))
-            if path:
-                result.thumbnail = path
-            else:
-                result.errors.append("thumbnail export failed")
-            continue
-
-        if fmt not in _dispatch:
-            result.errors.append(f"unknown format: {fmt!r}")
-            continue
-
-        exporter_fn, out_dir = _dispatch[fmt]
-        try:
-            path = exporter_fn(source_path, preset, out_dir)
-        except Exception as exc:
-            result.errors.append(f"{fmt} export raised: {exc}")
-            path = None
-
-        if path:
+        path, error = _run_exporter(fmt, source_path, preset, renders_root, dispatch)
+        if error:
+            result.errors.append(error)
+        else:
             if fmt == "png_sequence":
                 result.png_sequence_dir = path
-            else:
+            elif hasattr(result, fmt):
                 setattr(result, fmt, path)
-        else:
-            result.errors.append(f"{fmt} export returned None")
 
     return result
 

--- a/pipeline/exporters/__init__.py
+++ b/pipeline/exporters/__init__.py
@@ -383,7 +383,7 @@ def export_all(
         else:
             if fmt == "png_sequence":
                 result.png_sequence_dir = path
-            elif hasattr(result, fmt):
+            else:
                 setattr(result, fmt, path)
 
     return result

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -1,0 +1,35 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import pipeline.exporters as exporters
+from pipeline.motion_presets import MotionPreset
+
+
+class TestExportAllCustomFormats(unittest.TestCase):
+
+    def test_successful_format_without_declared_attribute_is_preserved(self):
+        preset = MotionPreset(id="spin", name="Spin")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "custom.out")
+
+            def export_custom(source_path, preset, output_dir):
+                os.makedirs(output_dir, exist_ok=True)
+                return output_path
+
+            dispatch = {"custom_format": (export_custom, tmpdir)}
+
+            with patch.object(exporters, "_get_dispatch", return_value=dispatch):
+                result = exporters.export_all(
+                    "asset1",
+                    "asset1.png",
+                    preset,
+                    renders_root=tmpdir,
+                    formats=["custom_format"],
+                )
+
+        self.assertEqual(result.errors, [])
+        self.assertTrue(hasattr(result, "custom_format"))
+        self.assertEqual(result.custom_format, output_path)


### PR DESCRIPTION
🎯 What: Extracted format mapping and export execution from export_all into helper methods.
💡 Why: Simplifying the main flow in export_all greatly improves readability and makes adding new formats easier.
✅ Verification: Ran syntax check with python -m py_compile, and executed tests using python test_exporter_script.py (which printed expected successful outputs), as well as using the test suite.
✨ Result: Code is cleaner and much more maintainable.

---
*PR created automatically by Jules for task [8418474304752564792](https://jules.google.com/task/8418474304752564792) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor of the exporter orchestration path; behavior should be equivalent but changes error handling flow and how outputs are assigned, so regressions would mainly show up as missing paths or new error strings.
> 
> **Overview**
> **Refactors `export_all` orchestration** by moving the format→exporter mapping into `_get_dispatch()` and the per-format execution/error handling into `_run_exporter()`, simplifying the main loop.
> 
> **Adds coverage** via `tests/test_exporters.py` to ensure a custom format injected through `_get_dispatch` is exported and stored on the `ExportResult` without producing errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fce3c33988f6231e9eb8cbd300b2e3593b312b5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->