### PR TITLE
🧹 [code health improvement] Remove unused validate_init_data import from stixmagic/__init__.py

### DIFF
--- a/stixmagic/__init__.py
+++ b/stixmagic/__init__.py
@@ -15,4 +15,4 @@ from .contracts import (  # noqa: F401
     START_PAYLOAD_MANAGE,
 )
 from .settings import AppSettings, get_settings  # noqa: F401
-from .telegram_auth import TelegramInitDataError, validate_init_data  # noqa: F401
+from .telegram_auth import TelegramInitDataError  # noqa: F401


### PR DESCRIPTION
🎯 What: Removed the unused `validate_init_data` import from `stixmagic/__init__.py`.
💡 Why: The import wasn't used internally or intended to be exported via `__init__.py`, making it dead code that cluttered the namespace.
✅ Verification: Ran `isort` and `black` to ensure formatting was correct. Verified that the `validate_init_data` import is only used directly from `stixmagic.telegram_auth` throughout the codebase. Ran the test suite to ensure no functionality is broken (specifically `test_api_helpers.py` and `test_stixmagic_telegram_auth.py`). 
✨ Result: Cleaner namespace and removed dead code, improving code health.

---
*PR created automatically by Jules for task [10695179596822542346](https://jules.google.com/task/10695179596822542346) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the public package exports by removing an unused re-export; no runtime logic changes.
> 
> **Overview**
> Removes the unused re-export of `validate_init_data` from `stixmagic/__init__.py`, leaving only `TelegramInitDataError` exposed from `telegram_auth`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab08bc60bcf954b1390d7cfbe2870c28408e583d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->