### PR TITLE
🧹 Refactor build_pack into smaller helper functions in pipeline/packager/__init__.py

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -38,3 +38,7 @@
 ## 2026-05-13 - Loop Invariant Code Motion and Lookup Optimization
 **Learning:** Found that `pipeline/packager/__init__.py::build_pack` had an O(Assets * Presets * Formats) nested loop that repeatedly performed identical dictionary lookups and conditional checks (like checking if the format was 'thumbnail') which were invariant for a given asset or the entire execution. This resulted in redundant work and slower execution.
 **Action:** Extracted loop invariants and pre-computed static values (e.g. format tuples, constant thumbnail paths) outside the inner loops. This minimizes repeated dictionary accesses and condition evaluations, yielding an ~23% performance improvement in manifest generation.
+
+## 2026-05-18 - [Code Health] Refactor build_pack function
+**Learning:** The `build_pack` function in `pipeline/packager/__init__.py` was overly complex, handling asset resolution, preset resolution, and entry building in a single large block. Breaking this down into smaller helper functions (`_resolve_assets`, `_resolve_presets`, `_build_entries`) significantly improves readability, testability, and maintainability without altering functionality.
+**Action:** When encountering functions that span over 100 lines and handle multiple distinct logical steps, proactively extract those steps into private helper functions with clear type hints to maintain code health.

--- a/pipeline/packager/__init__.py
+++ b/pipeline/packager/__init__.py
@@ -204,6 +204,83 @@ def validate_pack(
 
 # ── Build helper ──────────────────────────────────────────────
 
+def _resolve_assets(pack: PackDefinition, catalog: Any) -> list[Asset]:
+    if pack.included_assets:
+        return [
+            a for aid in pack.included_assets
+            if (a := catalog.get(aid)) is not None
+        ]
+    return catalog.all()
+
+
+def _resolve_presets(pack: PackDefinition) -> list[Any]:
+    from pipeline.motion_presets import get_preset, BUILTIN_PRESETS
+    if pack.included_motion_presets:
+        return [p for pid in pack.included_motion_presets if (p := get_preset(pid)) is not None]
+    return list(BUILTIN_PRESETS)
+
+
+def _build_entries(
+    pack: PackDefinition,
+    assets: list[Asset],
+    presets: list[Any],
+    renders_root: str,
+) -> list[PackManifestEntry]:
+    _dir_map = {
+        "gif":          os.path.join(renders_root, "gif"),
+        "webp":         os.path.join(renders_root, "webp"),
+        "webm":         os.path.join(renders_root, "webm"),
+        "mov":          os.path.join(renders_root, "mov"),
+        "png_sequence": os.path.join(renders_root, "png_sequences"),
+        "thumbnail":    os.path.join(renders_root, "thumbnails"),
+    }
+    _ext_map = {
+        "gif": "gif", "webp": "webp", "webm": "webm",
+        "mov": "mov", "thumbnail": "png",
+    }
+
+    # ⚡ Bolt Optimization: Pre-compute formats and loop invariants
+    # Impact: Reduces O(Assets * Presets * Formats) dictionary lookups and path building
+    has_thumb = "thumbnail" in pack.export_formats
+    has_seq = "png_sequence" in pack.export_formats
+    thumb_dir = _dir_map.get("thumbnail")
+    seq_dir = _dir_map.get("png_sequence")
+
+    other_formats = [
+        (fmt, _ext_map.get(fmt, fmt), _dir_map[fmt])
+        for fmt in pack.export_formats
+        if fmt not in ("thumbnail", "png_sequence") and fmt in _dir_map
+    ]
+
+    entries = []
+    for asset in assets:
+        asset_id = asset.id
+        # Thumbnail only depends on the asset, not the preset
+        thumb_path = os.path.join(thumb_dir, f"{asset_id}_thumb.png") if has_thumb else None
+
+        for preset in presets:
+            preset_id = preset.id
+            outputs: dict[str, str] = {}
+
+            if has_thumb and thumb_path:
+                outputs["thumbnail"] = thumb_path
+
+            if has_seq and seq_dir:
+                outputs["png_sequence"] = os.path.join(seq_dir, f"{asset_id}_{preset_id}_frames")
+
+            for fmt, ext, fdir in other_formats:
+                outputs[fmt] = os.path.join(fdir, f"{asset_id}_{preset_id}.{ext}")
+
+            entries.append(
+                PackManifestEntry(
+                    asset_id=asset_id,
+                    preset_id=preset_id,
+                    expected_outputs=outputs,
+                )
+            )
+    return entries
+
+
 def build_pack(
     pack: PackDefinition,
     catalog: Any,  # pipeline.metadata.AssetCatalog
@@ -246,74 +323,11 @@ def build_pack(
     # Validate referenced assets and presets before building the manifest
     validate_pack(pack, catalog, strict=strict_validation)
 
-    # Resolve assets
-    if pack.included_assets:
-        assets: list[Asset] = [
-            a for aid in pack.included_assets
-            if (a := catalog.get(aid)) is not None
-        ]
-    else:
-        assets = catalog.all()
+    assets = _resolve_assets(pack, catalog)
+    presets = _resolve_presets(pack)
+    entries = _build_entries(pack, assets, presets, renders_root)
 
-    # Resolve presets
-    if pack.included_motion_presets:
-        presets = [p for pid in pack.included_motion_presets if (p := get_preset(pid)) is not None]
-    else:
-        presets = list(BUILTIN_PRESETS)
-
-    manifest = PackManifest(pack_id=pack.pack_id)
-
-    _dir_map = {
-        "gif":          os.path.join(renders_root, "gif"),
-        "webp":         os.path.join(renders_root, "webp"),
-        "webm":         os.path.join(renders_root, "webm"),
-        "mov":          os.path.join(renders_root, "mov"),
-        "png_sequence": os.path.join(renders_root, "png_sequences"),
-        "thumbnail":    os.path.join(renders_root, "thumbnails"),
-    }
-    _ext_map = {
-        "gif": "gif", "webp": "webp", "webm": "webm",
-        "mov": "mov", "thumbnail": "png",
-    }
-
-    # ⚡ Bolt Optimization: Pre-compute formats and loop invariants
-    # Impact: Reduces O(Assets * Presets * Formats) dictionary lookups and path building
-    has_thumb = "thumbnail" in pack.export_formats
-    has_seq = "png_sequence" in pack.export_formats
-    thumb_dir = _dir_map.get("thumbnail")
-    seq_dir = _dir_map.get("png_sequence")
-
-    other_formats = [
-        (fmt, _ext_map.get(fmt, fmt), _dir_map[fmt])
-        for fmt in pack.export_formats
-        if fmt not in ("thumbnail", "png_sequence") and fmt in _dir_map
-    ]
-
-    for asset in assets:
-        asset_id = asset.id
-        # Thumbnail only depends on the asset, not the preset
-        thumb_path = os.path.join(thumb_dir, f"{asset_id}_thumb.png") if has_thumb else None
-
-        for preset in presets:
-            preset_id = preset.id
-            outputs: dict[str, str] = {}
-
-            if has_thumb and thumb_path:
-                outputs["thumbnail"] = thumb_path
-
-            if has_seq and seq_dir:
-                outputs["png_sequence"] = os.path.join(seq_dir, f"{asset_id}_{preset_id}_frames")
-
-            for fmt, ext, fdir in other_formats:
-                outputs[fmt] = os.path.join(fdir, f"{asset_id}_{preset_id}.{ext}")
-
-            manifest.entries.append(
-                PackManifestEntry(
-                    asset_id=asset_id,
-                    preset_id=preset_id,
-                    expected_outputs=outputs,
-                )
-            )
+    manifest = PackManifest(pack_id=pack.pack_id, entries=entries)
 
     logger.info("build_pack: %s", manifest.summary())
     return manifest


### PR DESCRIPTION
🎯 **What:** Extracted the asset resolution, preset resolution, and entry building loops from `build_pack` into smaller, private helper functions: `_resolve_assets`, `_resolve_presets`, and `_build_entries`.
💡 **Why:** The original `build_pack` function was overly long and complex, mixing validation, resolution, and logic mapping for the manifest build entries. Breaking these down makes the individual functions more atomic, significantly improving readability, testability, and code maintainability.
✅ **Verification:** Reviewed the `pipeline/packager/__init__.py` file structure visually. Confirmed syntax is correct by running `python3 -m py_compile`. Executed the main test suite with `TELEGRAM_BOT_TOKEN=dummy STIXMAGIC_API_KEY=supersecret poetry run python -m unittest discover tests` ensuring no tests failed because of this refactoring (aside from preexisting unconnected ones).
✨ **Result:** A much cleaner `build_pack` function that reads like a sequence of clear instructions, improving the code health of the pack generation module.

---
*PR created automatically by Jules for task [16523784033932688600](https://jules.google.com/task/16523784033932688600) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor with no intended behavior change, but it touches manifest construction and could subtly alter asset/preset inclusion or output path enumeration if a helper differs from the previous inline logic.
> 
> **Overview**
> **Refactors pack manifest generation for readability.** `build_pack` in `pipeline/packager/__init__.py` is split into `_resolve_assets`, `_resolve_presets`, and `_build_entries`, and now builds the `PackManifest` from a returned entries list instead of mutating `manifest.entries` in-place.
> 
> Updates `.jules/bolt.md` with a code-health note documenting the refactor guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea8b3011e6d9522e48029fe9c271f07a957b5ac8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->