### PR TITLE
🧹 [Code Health] Extract business logic from generate_pipeline_manifest

### DIFF
--- a/pipeline/manifest.py
+++ b/pipeline/manifest.py
@@ -71,70 +71,24 @@ DEFAULT_PACKS_DIR = "packs"
 DEFAULT_RENDERS_ROOT = "renders"
 
 
-def generate_pipeline_manifest(
+def build_pipeline_manifest(
+    packs: list[Any],  # list[pipeline.packager.PackDefinition]
+    catalog: Any,      # pipeline.metadata.AssetCatalog
     *,
-    output_path: str = DEFAULT_MANIFEST_PATH,
-    packs_dir: str = DEFAULT_PACKS_DIR,
     renders_root: str = DEFAULT_RENDERS_ROOT,
-    catalog_path: str | None = None,
 ) -> dict[str, Any]:
     """
-    Build and write a ``pipeline_manifest.json`` for all defined packs.
+    Build the pipeline manifest dictionary from a list of packs.
 
-    Discovers all ``pack.json`` files under *packs_dir*, loads the asset
-    catalog, and calls :func:`~pipeline.packager.build_pack` for each pack
-    to produce the manifest.
-
-    Parameters
-    ----------
-    output_path:
-        Path where the manifest JSON will be written
-        (default: ``"pipeline_manifest.json"`` in the working directory).
-    packs_dir:
-        Directory containing per-pack subdirectories with ``pack.json`` files.
-    renders_root:
-        Root directory of the export outputs tree (for output path resolution).
-    catalog_path:
-        Override the default asset catalog path.  ``None`` uses the built-in
-        default (``assets/catalog.json``).
-
-    Returns
-    -------
-    dict
-        The full manifest as a Python dict (also written to *output_path*).
+    This function contains the pure business logic of resolving entries,
+    and formats them according to the manifest JSON schema.
     """
-    from pipeline.metadata import AssetCatalog
-    from pipeline.packager import PackDefinition, build_pack
-
-    # Load asset catalog
-    catalog_kwargs: dict[str, Any] = {"auto_load": True}
-    if catalog_path is not None:
-        catalog_kwargs["path"] = catalog_path
-    catalog = AssetCatalog(**catalog_kwargs)
-
-    # Discover pack definitions
-    pack_json_files: list[str] = []
-    if os.path.isdir(packs_dir):
-        for entry in sorted(os.listdir(packs_dir)):
-            candidate = os.path.join(packs_dir, entry, "pack.json")
-            if os.path.isfile(candidate):
-                pack_json_files.append(candidate)
-
-    if not pack_json_files:
-        logger.warning(
-            "generate_pipeline_manifest: no pack.json files found under %r", packs_dir
-        )
+    from pipeline.packager import build_pack
 
     manifest_packs: list[dict[str, Any]] = []
     total_assets_seen: set[str] = set()
 
-    for pack_file in pack_json_files:
-        try:
-            pack = PackDefinition.from_file(pack_file)
-        except Exception as exc:
-            logger.error("Skipping %s – failed to load: %s", pack_file, exc)
-            continue
-
+    for pack in packs:
         try:
             pack_manifest = build_pack(
                 pack, catalog, renders_root=renders_root, strict_validation=False
@@ -168,7 +122,7 @@ def generate_pipeline_manifest(
             "export_formats":  pack.export_formats,
             "entries":         entries,
         })
-        logger.info("generate_pipeline_manifest: added pack %r (%d entries)", pack.pack_id, len(entries))
+        logger.info("build_pipeline_manifest: added pack %r (%d entries)", pack.pack_id, len(entries))
 
     manifest: dict[str, Any] = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -177,12 +131,82 @@ def generate_pipeline_manifest(
         "packs":        manifest_packs,
     }
 
+    return manifest
+
+
+def generate_pipeline_manifest(
+    *,
+    output_path: str = DEFAULT_MANIFEST_PATH,
+    packs_dir: str = DEFAULT_PACKS_DIR,
+    renders_root: str = DEFAULT_RENDERS_ROOT,
+    catalog_path: str | None = None,
+) -> dict[str, Any]:
+    """
+    Build and write a ``pipeline_manifest.json`` for all defined packs.
+
+    Discovers all ``pack.json`` files under *packs_dir*, loads the asset
+    catalog, and calls :func:`build_pipeline_manifest` for each pack
+    to produce the manifest.
+
+    Parameters
+    ----------
+    output_path:
+        Path where the manifest JSON will be written
+        (default: ``"pipeline_manifest.json"`` in the working directory).
+    packs_dir:
+        Directory containing per-pack subdirectories with ``pack.json`` files.
+    renders_root:
+        Root directory of the export outputs tree (for output path resolution).
+    catalog_path:
+        Override the default asset catalog path.  ``None`` uses the built-in
+        default (``assets/catalog.json``).
+
+    Returns
+    -------
+    dict
+        The full manifest as a Python dict (also written to *output_path*).
+    """
+    from pipeline.metadata import AssetCatalog
+    from pipeline.packager import PackDefinition
+
+    # Load asset catalog
+    catalog_kwargs: dict[str, Any] = {"auto_load": True}
+    if catalog_path is not None:
+        catalog_kwargs["path"] = catalog_path
+    catalog = AssetCatalog(**catalog_kwargs)
+
+    # Discover pack definitions
+    pack_json_files: list[str] = []
+    if os.path.isdir(packs_dir):
+        with os.scandir(packs_dir) as it:
+            for entry in sorted(it, key=lambda e: e.name):
+                if entry.is_dir():
+                    candidate = os.path.join(entry.path, "pack.json")
+                    if os.path.isfile(candidate):
+                        pack_json_files.append(candidate)
+
+    if not pack_json_files:
+        logger.warning(
+            "generate_pipeline_manifest: no pack.json files found under %r", packs_dir
+        )
+
+    packs = []
+    for pack_file in pack_json_files:
+        try:
+            pack = PackDefinition.from_file(pack_file)
+            packs.append(pack)
+        except Exception as exc:
+            logger.error("Skipping %s – failed to load: %s", pack_file, exc)
+            continue
+
+    manifest = build_pipeline_manifest(packs, catalog, renders_root=renders_root)
+
     try:
         with open(output_path, "w", encoding="utf-8") as fh:
             json.dump(manifest, fh, indent=2)
         logger.info(
             "generate_pipeline_manifest: wrote %d packs / %d unique assets to %s",
-            len(manifest_packs), len(total_assets_seen), output_path,
+            manifest["total_packs"], manifest["total_assets"], output_path,
         )
     except Exception as exc:
         logger.error("Failed to write manifest to %s: %s", output_path, exc)

--- a/tests/test_pipeline_manifest.py
+++ b/tests/test_pipeline_manifest.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from pipeline.manifest import build_pipeline_manifest
+from pipeline.packager import PackDefinition
+
+class TestPipelineManifest(unittest.TestCase):
+    @patch("pipeline.packager.build_pack")
+    def test_build_pipeline_manifest(self, mock_build_pack):
+        # Setup mock PackManifest from build_pack
+        mock_pack_manifest = MagicMock()
+
+        mock_entry = MagicMock()
+        mock_entry.asset_id = "test_asset"
+        mock_entry.preset_id = "test_preset"
+        mock_entry.expected_outputs = {
+            "thumbnail": "thumb.png",
+            "gif": "output.gif"
+        }
+        mock_pack_manifest.entries = [mock_entry]
+        mock_build_pack.return_value = mock_pack_manifest
+
+        # Setup mock AssetCatalog
+        mock_catalog = MagicMock()
+        mock_asset = MagicMock()
+        mock_asset.name = "Test Asset"
+        mock_asset.category.value = "test_category"
+        mock_catalog.get.return_value = mock_asset
+
+        # Setup PackDefinition
+        pack = PackDefinition(
+            pack_id="test_pack",
+            title="Test Pack",
+            theme="test_theme",
+            target_platforms=["platform1"],
+            export_formats=["gif"]
+        )
+
+        manifest = build_pipeline_manifest([pack], mock_catalog, renders_root="renders")
+
+        self.assertIn("generated_at", manifest)
+        self.assertEqual(manifest["total_packs"], 1)
+        self.assertEqual(manifest["total_assets"], 1)
+        self.assertEqual(len(manifest["packs"]), 1)
+
+        pack_data = manifest["packs"][0]
+        self.assertEqual(pack_data["pack_id"], "test_pack")
+        self.assertEqual(pack_data["title"], "Test Pack")
+        self.assertEqual(pack_data["theme"], "test_theme")
+        self.assertEqual(pack_data["target_platforms"], ["platform1"])
+        self.assertEqual(pack_data["export_formats"], ["gif"])
+
+        self.assertEqual(len(pack_data["entries"]), 1)
+        entry_data = pack_data["entries"][0]
+        self.assertEqual(entry_data["asset_id"], "test_asset")
+        self.assertEqual(entry_data["asset_name"], "Test Asset")
+        self.assertEqual(entry_data["asset_category"], "test_category")
+        self.assertEqual(entry_data["preset_id"], "test_preset")
+        self.assertEqual(entry_data["thumbnail"], "thumb.png")
+        self.assertEqual(entry_data["outputs"], {"gif": "output.gif"})
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 What: Refactored `generate_pipeline_manifest` in `pipeline/manifest.py` by extracting its business logic into a new `build_pipeline_manifest` function. Added tests for this new isolated logic.
💡 Why: Mixing file I/O operations with business logic made it impossible to test the pack resolution logic without mocking the filesystem. Extracting the pure logic loop improves modularity and testability.
✅ Verification: Created `tests/test_pipeline_manifest.py` to verify the JSON structure generation purely logically with Python mocks. Ran the entire test suite locally to ensure no pre-existing workflows were broken.
✨ Result: Highly maintainable manifest generator that can be tested in isolation, alongside minor performance improvements via `os.scandir`.

---
*PR created automatically by Jules for task [5226183808679351311](https://jules.google.com/task/5226183808679351311) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that mainly moves manifest-building logic into a new helper and adds a focused unit test; behavior should remain the same aside from pack discovery using `os.scandir`.
> 
> **Overview**
> **Refactors manifest generation** by extracting the pack/entry resolution and JSON shaping into a new pure helper `build_pipeline_manifest`, leaving `generate_pipeline_manifest` to handle catalog loading, pack discovery, and file I/O.
> 
> **Minor behavior/impl tweaks**: pack discovery now uses `os.scandir` (still sorted) and logging now reports totals from the returned manifest; adds `tests/test_pipeline_manifest.py` to validate the generated manifest structure with mocks (including thumbnail filtering into `outputs`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22076908e1f7faa2897f250586ff06429a03384c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->