### PR TITLE
🧹 Refactor build_pack by extracting helpers

### DIFF
--- a/pipeline/packager/__init__.py
+++ b/pipeline/packager/__init__.py
@@ -202,6 +202,86 @@ def validate_pack(
     return errors
 
 
+# ── Build helpers ─────────────────────────────────────────────
+
+def _resolve_assets(pack: PackDefinition, catalog: Any) -> list[Asset]:
+    if pack.included_assets:
+        return [
+            a for aid in pack.included_assets
+            if (a := catalog.get(aid)) is not None
+        ]
+    return catalog.all()
+
+
+def _resolve_presets(pack: PackDefinition) -> list[Any]:
+    from pipeline.motion_presets import get_preset, BUILTIN_PRESETS
+    if pack.included_motion_presets:
+        return [p for pid in pack.included_motion_presets if (p := get_preset(pid)) is not None]
+    return list(BUILTIN_PRESETS)
+
+
+def _build_entries(
+    pack: PackDefinition,
+    assets: list[Asset],
+    presets: list[Any],
+    renders_root: str
+) -> list[PackManifestEntry]:
+    _dir_map = {
+        "gif":          os.path.join(renders_root, "gif"),
+        "webp":         os.path.join(renders_root, "webp"),
+        "webm":         os.path.join(renders_root, "webm"),
+        "mov":          os.path.join(renders_root, "mov"),
+        "png_sequence": os.path.join(renders_root, "png_sequences"),
+        "thumbnail":    os.path.join(renders_root, "thumbnails"),
+    }
+    _ext_map = {
+        "gif": "gif", "webp": "webp", "webm": "webm",
+        "mov": "mov", "thumbnail": "png",
+    }
+
+    # ⚡ Bolt Optimization: Pre-compute formats and loop invariants
+    # Impact: Reduces O(Assets * Presets * Formats) dictionary lookups and path building
+    has_thumb = "thumbnail" in pack.export_formats
+    has_seq = "png_sequence" in pack.export_formats
+    thumb_dir = _dir_map.get("thumbnail")
+    seq_dir = _dir_map.get("png_sequence")
+
+    other_formats = [
+        (fmt, _ext_map.get(fmt, fmt), _dir_map[fmt])
+        for fmt in pack.export_formats
+        if fmt not in ("thumbnail", "png_sequence") and fmt in _dir_map
+    ]
+
+    entries = []
+    for asset in assets:
+        asset_id = asset.id
+        # Thumbnail only depends on the asset, not the preset
+        thumb_path = os.path.join(thumb_dir, f"{asset_id}_thumb.png") if has_thumb and thumb_dir else None
+
+        for preset in presets:
+            preset_id = preset.id
+            outputs: dict[str, str] = {}
+
+            if has_thumb and thumb_path:
+                outputs["thumbnail"] = thumb_path
+
+            if has_seq and seq_dir:
+                outputs["png_sequence"] = os.path.join(seq_dir, f"{asset_id}_{preset_id}_frames")
+
+            for fmt, ext, fdir in other_formats:
+                outputs[fmt] = os.path.join(fdir, f"{asset_id}_{preset_id}.{ext}")
+
+            entries.append(
+                PackManifestEntry(
+                    asset_id=asset_id,
+                    preset_id=preset_id,
+                    expected_outputs=outputs,
+                )
+            )
+
+    return entries
+
+
 # ── Build helper ──────────────────────────────────────────────
 
 def build_pack(
@@ -241,79 +321,15 @@ def build_pack(
     PackValidationError
         When ``strict_validation=True`` and an invalid reference is found.
     """
-    from pipeline.motion_presets import get_preset, BUILTIN_PRESETS
-
     # Validate referenced assets and presets before building the manifest
     validate_pack(pack, catalog, strict=strict_validation)
 
-    # Resolve assets
-    if pack.included_assets:
-        assets: list[Asset] = [
-            a for aid in pack.included_assets
-            if (a := catalog.get(aid)) is not None
-        ]
-    else:
-        assets = catalog.all()
-
-    # Resolve presets
-    if pack.included_motion_presets:
-        presets = [p for pid in pack.included_motion_presets if (p := get_preset(pid)) is not None]
-    else:
-        presets = list(BUILTIN_PRESETS)
+    assets = _resolve_assets(pack, catalog)
+    presets = _resolve_presets(pack)
+    entries = _build_entries(pack, assets, presets, renders_root)
 
     manifest = PackManifest(pack_id=pack.pack_id)
-
-    _dir_map = {
-        "gif":          os.path.join(renders_root, "gif"),
-        "webp":         os.path.join(renders_root, "webp"),
-        "webm":         os.path.join(renders_root, "webm"),
-        "mov":          os.path.join(renders_root, "mov"),
-        "png_sequence": os.path.join(renders_root, "png_sequences"),
-        "thumbnail":    os.path.join(renders_root, "thumbnails"),
-    }
-    _ext_map = {
-        "gif": "gif", "webp": "webp", "webm": "webm",
-        "mov": "mov", "thumbnail": "png",
-    }
-
-    # ⚡ Bolt Optimization: Pre-compute formats and loop invariants
-    # Impact: Reduces O(Assets * Presets * Formats) dictionary lookups and path building
-    has_thumb = "thumbnail" in pack.export_formats
-    has_seq = "png_sequence" in pack.export_formats
-    thumb_dir = _dir_map.get("thumbnail")
-    seq_dir = _dir_map.get("png_sequence")
-
-    other_formats = [
-        (fmt, _ext_map.get(fmt, fmt), _dir_map[fmt])
-        for fmt in pack.export_formats
-        if fmt not in ("thumbnail", "png_sequence") and fmt in _dir_map
-    ]
-
-    for asset in assets:
-        asset_id = asset.id
-        # Thumbnail only depends on the asset, not the preset
-        thumb_path = os.path.join(thumb_dir, f"{asset_id}_thumb.png") if has_thumb else None
-
-        for preset in presets:
-            preset_id = preset.id
-            outputs: dict[str, str] = {}
-
-            if has_thumb and thumb_path:
-                outputs["thumbnail"] = thumb_path
-
-            if has_seq and seq_dir:
-                outputs["png_sequence"] = os.path.join(seq_dir, f"{asset_id}_{preset_id}_frames")
-
-            for fmt, ext, fdir in other_formats:
-                outputs[fmt] = os.path.join(fdir, f"{asset_id}_{preset_id}.{ext}")
-
-            manifest.entries.append(
-                PackManifestEntry(
-                    asset_id=asset_id,
-                    preset_id=preset_id,
-                    expected_outputs=outputs,
-                )
-            )
+    manifest.entries.extend(entries)
 
     logger.info("build_pack: %s", manifest.summary())
     return manifest

--- a/tests/test_pipeline_packager.py
+++ b/tests/test_pipeline_packager.py
@@ -1,0 +1,100 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from pipeline.asset_model import Asset
+from pipeline.packager import PackDefinition, PackManifestEntry
+from pipeline.packager import _resolve_assets, _resolve_presets, _build_entries
+
+class TestPipelinePackagerHelpers(unittest.TestCase):
+    def test_resolve_assets_all(self):
+        catalog_mock = MagicMock()
+        asset1 = MagicMock(spec=Asset)
+        asset1.id = "asset1"
+        asset2 = MagicMock(spec=Asset)
+        asset2.id = "asset2"
+        catalog_mock.all.return_value = [asset1, asset2]
+
+        pack = PackDefinition(pack_id="test_pack", title="Test Pack") # empty included_assets
+
+        assets = _resolve_assets(pack, catalog_mock)
+        self.assertEqual(len(assets), 2)
+        self.assertEqual(assets[0].id, "asset1")
+        self.assertEqual(assets[1].id, "asset2")
+        catalog_mock.all.assert_called_once()
+        catalog_mock.get.assert_not_called()
+
+    def test_resolve_assets_subset(self):
+        catalog_mock = MagicMock()
+        asset1 = MagicMock(spec=Asset)
+        asset1.id = "asset1"
+        catalog_mock.get.side_effect = lambda aid: asset1 if aid == "asset1" else None
+
+        pack = PackDefinition(pack_id="test_pack", title="Test Pack", included_assets=["asset1", "missing_asset"])
+
+        assets = _resolve_assets(pack, catalog_mock)
+        self.assertEqual(len(assets), 1)
+        self.assertEqual(assets[0].id, "asset1")
+        catalog_mock.all.assert_not_called()
+        self.assertEqual(catalog_mock.get.call_count, 2)
+
+    @patch("pipeline.packager.__init__.BUILTIN_PRESETS", create=True)
+    def test_resolve_presets_all(self, builtin_presets_mock):
+        preset_mock = MagicMock()
+        preset_mock.id = "builtin_preset"
+        builtin_presets_mock.__iter__.return_value = [preset_mock]
+
+        pack = PackDefinition(pack_id="test_pack", title="Test Pack")
+
+        with patch("pipeline.motion_presets.BUILTIN_PRESETS", [preset_mock]):
+            presets = _resolve_presets(pack)
+            self.assertEqual(len(presets), 1)
+            self.assertEqual(presets[0].id, "builtin_preset")
+
+    @patch("pipeline.packager.__init__.get_preset", create=True)
+    def test_resolve_presets_subset(self, get_preset_mock):
+        preset_mock = MagicMock()
+        preset_mock.id = "preset1"
+        get_preset_mock.side_effect = lambda pid: preset_mock if pid == "preset1" else None
+
+        pack = PackDefinition(pack_id="test_pack", title="Test Pack", included_motion_presets=["preset1", "missing_preset"])
+
+        with patch("pipeline.motion_presets.get_preset", side_effect=lambda pid: preset_mock if pid == "preset1" else None):
+            presets = _resolve_presets(pack)
+            self.assertEqual(len(presets), 1)
+            self.assertEqual(presets[0].id, "preset1")
+
+    def test_build_entries(self):
+        pack = PackDefinition(
+            pack_id="test_pack",
+            title="Test Pack",
+            export_formats=["gif", "png_sequence", "thumbnail", "webm"]
+        )
+        asset1 = MagicMock(spec=Asset)
+        asset1.id = "asset1"
+
+        preset_mock = MagicMock()
+        preset_mock.id = "preset1"
+
+        assets = [asset1]
+        presets = [preset_mock]
+        renders_root = "renders"
+
+        entries = _build_entries(pack, assets, presets, renders_root)
+
+        self.assertEqual(len(entries), 1)
+        entry = entries[0]
+        self.assertEqual(entry.asset_id, "asset1")
+        self.assertEqual(entry.preset_id, "preset1")
+
+        self.assertIn("gif", entry.expected_outputs)
+        self.assertIn("webm", entry.expected_outputs)
+        self.assertIn("thumbnail", entry.expected_outputs)
+        self.assertIn("png_sequence", entry.expected_outputs)
+
+        self.assertTrue(entry.expected_outputs["gif"].endswith("asset1_preset1.gif"))
+        self.assertTrue(entry.expected_outputs["webm"].endswith("asset1_preset1.webm"))
+        self.assertTrue(entry.expected_outputs["thumbnail"].endswith("asset1_thumb.png"))
+        self.assertTrue(entry.expected_outputs["png_sequence"].endswith("asset1_preset1_frames"))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 What: Extracted `_resolve_assets`, `_resolve_presets`, and `_build_entries` helpers from `build_pack` in `pipeline/packager/__init__.py`.
💡 Why: Reduces the length and complexity of the `build_pack` function making it more readable and testable.
✅ Verification: Created unit tests for the extracted helpers in `tests/test_pipeline_packager.py` and ran the full test suite. No new regressions were introduced, and the new tests pass.
✨ Result: Improved maintainability and testability of packager logic.

---
*PR created automatically by Jules for task [2715937291516755860](https://jules.google.com/task/2715937291516755860) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that mainly extracts logic into helper functions and adds tests; only minor behavior tweak is additional guarding when computing thumbnail paths.
> 
> **Overview**
> Refactors `build_pack` by extracting `_resolve_assets`, `_resolve_presets`, and `_build_entries`, making the pack manifest construction easier to test and reason about.
> 
> Adds a new unit test module validating asset/preset selection behavior and expected output path generation, and slightly hardens thumbnail path computation by guarding against a missing thumbnail directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6575f21b6a91def445e688c639da75819d6277a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->