### PR TITLE
🧹 [Code Health] Refactor build_pack function to improve readability

### DIFF
--- a/pipeline/packager/__init__.py
+++ b/pipeline/packager/__init__.py
@@ -204,6 +204,73 @@ def validate_pack(
 
 # ── Build helper ──────────────────────────────────────────────
 
+
+
+def _resolve_assets(pack: PackDefinition, catalog: Any) -> list[Asset]:
+    """Resolve the list of assets included in the pack."""
+    if pack.included_assets:
+        return [
+            a for aid in pack.included_assets
+            if (a := catalog.get(aid)) is not None
+        ]
+    return catalog.all()
+
+
+def _resolve_presets(pack: PackDefinition) -> list[Any]:
+    """Resolve the list of motion presets included in the pack."""
+    from pipeline.motion_presets import get_preset, BUILTIN_PRESETS
+    if pack.included_motion_presets:
+        return [p for pid in pack.included_motion_presets if (p := get_preset(pid)) is not None]
+    return list(BUILTIN_PRESETS)
+
+
+def _build_entries(pack: PackDefinition, assets: list[Asset], presets: list[Any], renders_root: str) -> list[PackManifestEntry]:
+    """Generate the expected outputs for all asset/preset combinations."""
+    _dir_map = {
+        "gif":          os.path.join(renders_root, "gif"),
+        "webp":         os.path.join(renders_root, "webp"),
+        "webm":         os.path.join(renders_root, "webm"),
+        "mov":          os.path.join(renders_root, "mov"),
+        "png_sequence": os.path.join(renders_root, "png_sequences"),
+        "thumbnail":    os.path.join(renders_root, "thumbnails"),
+    }
+    _ext_map = {
+        "gif": "gif", "webp": "webp", "webm": "webm",
+        "mov": "mov", "thumbnail": "png",
+    }
+
+    # ⚡ Bolt Optimization: Pre-compute formats and loop invariants
+    # Impact: Reduces O(Assets * Presets * Formats) dictionary lookups and path building
+    has_thumb = "thumbnail" in pack.export_formats
+    has_seq = "png_sequence" in pack.export_formats
+    thumb_dir = _dir_map.get("thumbnail")
+    seq_dir = _dir_map.get("png_sequence")
+
+    other_formats = [
+        (fmt, _ext_map.get(fmt, fmt), _dir_map[fmt])
+        for fmt in pack.export_formats
+        if fmt not in ("thumbnail", "png_sequence") and fmt in _dir_map
+    ]
+
+    entries: list[PackManifestEntry] = []
+    for asset in assets:
+        asset_id = asset.id
+        # Thumbnail only depends on the asset, not the preset
+        thumb_path = os.path.join(thumb_dir, f"{asset_id}_thumb.png") if has_thumb and thumb_dir else None
+
+        for preset in presets:
+            preset_id = preset.id
+            outputs: dict[str, str] = {}
+            if has_thumb and thumb_path:
+                outputs["thumbnail"] = thumb_path
+            if has_seq and seq_dir:
+                outputs["png_sequence"] = os.path.join(seq_dir, f"{asset_id}_{preset_id}_frames")
+            for fmt, ext, fdir in other_formats:
+                outputs[fmt] = os.path.join(fdir, f"{asset_id}_{preset_id}.{ext}")
+            entries.append(PackManifestEntry(asset_id=asset_id, preset_id=preset_id, expected_outputs=outputs))
+    return entries
+
+
 def build_pack(
     pack: PackDefinition,
     catalog: Any,  # pipeline.metadata.AssetCatalog
@@ -241,79 +308,14 @@ def build_pack(
     PackValidationError
         When ``strict_validation=True`` and an invalid reference is found.
     """
-    from pipeline.motion_presets import get_preset, BUILTIN_PRESETS
-
     # Validate referenced assets and presets before building the manifest
     validate_pack(pack, catalog, strict=strict_validation)
 
-    # Resolve assets
-    if pack.included_assets:
-        assets: list[Asset] = [
-            a for aid in pack.included_assets
-            if (a := catalog.get(aid)) is not None
-        ]
-    else:
-        assets = catalog.all()
-
-    # Resolve presets
-    if pack.included_motion_presets:
-        presets = [p for pid in pack.included_motion_presets if (p := get_preset(pid)) is not None]
-    else:
-        presets = list(BUILTIN_PRESETS)
+    assets = _resolve_assets(pack, catalog)
+    presets = _resolve_presets(pack)
 
     manifest = PackManifest(pack_id=pack.pack_id)
-
-    _dir_map = {
-        "gif":          os.path.join(renders_root, "gif"),
-        "webp":         os.path.join(renders_root, "webp"),
-        "webm":         os.path.join(renders_root, "webm"),
-        "mov":          os.path.join(renders_root, "mov"),
-        "png_sequence": os.path.join(renders_root, "png_sequences"),
-        "thumbnail":    os.path.join(renders_root, "thumbnails"),
-    }
-    _ext_map = {
-        "gif": "gif", "webp": "webp", "webm": "webm",
-        "mov": "mov", "thumbnail": "png",
-    }
-
-    # ⚡ Bolt Optimization: Pre-compute formats and loop invariants
-    # Impact: Reduces O(Assets * Presets * Formats) dictionary lookups and path building
-    has_thumb = "thumbnail" in pack.export_formats
-    has_seq = "png_sequence" in pack.export_formats
-    thumb_dir = _dir_map.get("thumbnail")
-    seq_dir = _dir_map.get("png_sequence")
-
-    other_formats = [
-        (fmt, _ext_map.get(fmt, fmt), _dir_map[fmt])
-        for fmt in pack.export_formats
-        if fmt not in ("thumbnail", "png_sequence") and fmt in _dir_map
-    ]
-
-    for asset in assets:
-        asset_id = asset.id
-        # Thumbnail only depends on the asset, not the preset
-        thumb_path = os.path.join(thumb_dir, f"{asset_id}_thumb.png") if has_thumb else None
-
-        for preset in presets:
-            preset_id = preset.id
-            outputs: dict[str, str] = {}
-
-            if has_thumb and thumb_path:
-                outputs["thumbnail"] = thumb_path
-
-            if has_seq and seq_dir:
-                outputs["png_sequence"] = os.path.join(seq_dir, f"{asset_id}_{preset_id}_frames")
-
-            for fmt, ext, fdir in other_formats:
-                outputs[fmt] = os.path.join(fdir, f"{asset_id}_{preset_id}.{ext}")
-
-            manifest.entries.append(
-                PackManifestEntry(
-                    asset_id=asset_id,
-                    preset_id=preset_id,
-                    expected_outputs=outputs,
-                )
-            )
+    manifest.entries = _build_entries(pack, assets, presets, renders_root)
 
     logger.info("build_pack: %s", manifest.summary())
     return manifest


### PR DESCRIPTION
🎯 **What:** Extracted inner logic from the `build_pack` function into smaller, well-named helper functions (`_resolve_assets`, `_resolve_presets`, and `_build_entries`).
💡 **Why:** The `build_pack` function was overly long and complex, making it difficult to read, maintain, and unit test. Splitting it out creates isolated modules that handle resolving configuration components and building entries distinctively, leaving `build_pack` purely as an orchestrator.
✅ **Verification:** Verified safety by running a unit test using a dummy `AssetCatalog` object that executes `build_pack` end-to-end, confirming the logic correctly operates to produce the same non-None `PackManifest`. Also confirmed via running the main project test suite that there are no regressions caused by these changes.
✨ **Result:** Improved modularity and readability of the `pipeline/packager/__init__.py` logic without altering its behavior.

---
*PR created automatically by Jules for task [15304948180467088076](https://jules.google.com/task/15304948180467088076) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a readability refactor of pack manifest generation; behavior should be unchanged aside from minor guard logic around thumbnail path construction.
> 
> **Overview**
> Refactors `pipeline/packager/__init__.py` by splitting `build_pack` into focused helpers: `_resolve_assets`, `_resolve_presets`, and `_build_entries`, making `build_pack` an orchestration wrapper around validation and manifest assembly.
> 
> During extraction, manifest entry construction is centralized to return a list (assigned to `manifest.entries`) and adds a small safety guard to only build thumbnail paths when the thumbnail directory is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb2b8787021e46d6447b3e342c0746977780ce0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->