### PR TITLE
🧪 [testing improvement] Cover edge cases for main.py validate_and_sync_packs

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,7 +1,0 @@
-Title: 🧪 Test validate_pack_title failure in create_title
-
-🎯 **What:** The `create_title` handler in `main.py` lacked a unit test verifying its behaviour when a pack title validation failed.
-
-📊 **Coverage:** A new test case `test_mocked_validate_pack_title_false` was added to `tests/test_main_forge_handlers.py`. It uses a mock to ensure that a title validation returning `False` correctly causes the handler to prompt the user again by returning the `WAITING_TITLE` state and sending the appropriate error message via Telegram.
-
-✨ **Result:** Enhanced test coverage for edge cases involving pack title validation during the pack creation flow.

--- a/tests/test_main_forge_handlers.py
+++ b/tests/test_main_forge_handlers.py
@@ -759,5 +759,68 @@ class TestValidateAndSyncPacks(unittest.TestCase):
         self.assertEqual(valid, [("pack_name", "New Title")])
 
 
+
+    @patch("main.get_user_packs")
+    @patch("main.logger.warning")
+    def test_generic_exception_status_unknown(self, mock_warning, mock_get_packs):
+        mock_get_packs.return_value = [("pack_name", "Pack Title")]
+        bot = AsyncMock()
+
+        class CustomError(Exception):
+            pass
+
+        bot.get_sticker_set.side_effect = CustomError("Something weird happened")
+
+        valid = _run(validate_and_sync_packs(bot, 123))
+
+        self.assertEqual(valid, [])
+        mock_warning.assert_called_once()
+        self.assertIn("Could not validate pack pack_name: Something weird happened", mock_warning.call_args[0][0])
+        self.assertNotIn("pack_name", _main_mod._TG_PACK_CACHE)
+
+    @patch("main.time.time")
+    @patch("main.get_user_packs")
+    def test_cache_eviction_removes_unrelated_fresh_entries(self, mock_get_packs, mock_time):
+        mock_time.return_value = 1000.0
+        mock_get_packs.return_value = [] # no packs for user
+
+        # Add 1500 unrelated but fresh entries to cache (1000.0 - 800.0 = 200.0 < 300)
+        # So they don't get removed in the first block, but they do in the second block
+        for i in range(1500):
+            _main_mod._TG_PACK_CACHE[f"unrelated_pack_{i}"] = (800.0, "Unrelated Pack", "valid")
+
+        bot = AsyncMock()
+
+        valid = _run(validate_and_sync_packs(bot, 123))
+
+        self.assertEqual(len(_main_mod._TG_PACK_CACHE), 1000)
+        self.assertEqual(valid, [])
+
+    @patch("main.time.time")
+    @patch("main.get_user_packs")
+    def test_cache_eviction_removes_stale_entries(self, mock_get_packs, mock_time):
+        mock_time.return_value = 1000.0
+        mock_get_packs.return_value = [
+            ("active_pack", "Active Pack"),
+        ]
+
+        # Add 1500 expired entries (1000.0 - 500.0 = 500.0 > 300)
+        for i in range(1500):
+            _main_mod._TG_PACK_CACHE[f"expired_pack_{i}"] = (500.0 + (i / 10000.0), "Expired Pack", "valid")
+
+        bot = AsyncMock()
+        active_set = MagicMock()
+        active_set.title = "Active Pack"
+        bot.get_sticker_set.return_value = active_set
+
+        valid = _run(validate_and_sync_packs(bot, 123))
+
+        # Because all 1500 are expired, the FIRST block removes them all.
+        # Then we add 1 for active_pack
+        self.assertEqual(len(_main_mod._TG_PACK_CACHE), 1)
+        self.assertIn("active_pack", _main_mod._TG_PACK_CACHE)
+        self.assertEqual(valid, [("active_pack", "Active Pack")])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The `validate_and_sync_packs` function in `main.py` lacked test coverage, specifically for its error handling mechanism and capacity-based cache eviction logic (`_TG_PACK_CACHE`). It was identified as a gap making it risky to refactor in the future due to its dependency on the Telegram Bot API.

📊 **Coverage:** The following scenarios are now fully tested using mock techniques that safely decouple the tests from the actual Telegram API:
- Transient/Generic exceptions during API calls returning 'unknown' status.
- Cache eviction ensuring cache drops old entries exceeding the TTL when the threshold is hit.
- Cache size limitations correctly dropping unrelated entries while preserving active packs to strictly stay under 1000 items capacity.

✨ **Result:** Test coverage for `validate_and_sync_packs` in `main.py` has been brought closer to 100%. The test file `tests/test_main_forge_handlers.py` now asserts cache constraints effectively.

---
*PR created automatically by Jules for task [13056581173032100746](https://jules.google.com/task/13056581173032100746) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are test-only (plus deletion of a markdown description) and do not modify runtime behavior; main risk is brittle assertions around cache size/eviction timing.
> 
> **Overview**
> Improves test coverage for `main.validate_and_sync_packs` by adding cases for *generic/unknown exceptions* (ensuring a warning is logged and the pack isn’t cached) and for *capacity/TTL-based `_TG_PACK_CACHE` eviction* (dropping stale entries and trimming unrelated fresh entries down to 1000).
> 
> Removes `pr_description.md`, and fixes the missing newline at EOF in `tests/test_main_forge_handlers.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 814c209ec82335a6921cdf7d23010f478a03ac9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->