### PR TITLE
🧪 Add tests for send_menu in main.py

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,7 +1,6 @@
-Title: 🧪 Test validate_pack_title failure in create_title
-
-🎯 **What:** The `create_title` handler in `main.py` lacked a unit test verifying its behaviour when a pack title validation failed.
-
-📊 **Coverage:** A new test case `test_mocked_validate_pack_title_false` was added to `tests/test_main_forge_handlers.py`. It uses a mock to ensure that a title validation returning `False` correctly causes the handler to prompt the user again by returning the `WAITING_TITLE` state and sending the appropriate error message via Telegram.
-
-✨ **Result:** Enhanced test coverage for edge cases involving pack title validation during the pack creation flow.
+🎯 **What:** `main.py` was missing tests for the `send_menu` handler which orchestrates keyboard assembly and bot response editing/sending. This addresses the testing gap for a critical interaction point in the bot.
+📊 **Coverage:** The new test file (`tests/test_main_send_menu.py`) fully covers the `send_menu` function. It tests:
+  - Both branches (when invoked from a `callback_query` and when invoked from a standard `message`).
+  - Handling of the expected `BadRequest("Message is not modified")` which is safely ignored.
+  - Verification that other, unexpected `BadRequest` errors are properly propagated.
+✨ **Result:** Test coverage and reliability of the `main.py` menu sending logic are significantly improved, safeguarding against future regressions.

--- a/tests/test_main_send_menu.py
+++ b/tests/test_main_send_menu.py
@@ -1,0 +1,128 @@
+import asyncio
+import sys
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _patch_heavy_imports():
+    """Inject lightweight stubs for modules main.py pulls in at import time."""
+    telegram = MagicMock()
+    telegram.__name__ = "telegram"
+
+    # We need to explicitly add attributes that main.py expects
+    telegram.InputSticker = MagicMock()
+    telegram.InlineKeyboardMarkup = MagicMock()
+    telegram.InlineKeyboardButton = MagicMock()
+    telegram.Update = MagicMock()
+    telegram.InputMediaDocument = MagicMock()
+
+    telegram_ext = MagicMock()
+    telegram_ext.__name__ = "telegram.ext"
+    telegram_ext.ContextTypes = MagicMock()
+    telegram_ext.ContextTypes.DEFAULT_TYPE = MagicMock()
+
+    telegram_error = MagicMock()
+    telegram_error.__name__ = "telegram.error"
+    telegram_error.BadRequest = type("BadRequest", (Exception,), {})
+
+    sys.modules["telegram"] = telegram
+    sys.modules["telegram.ext"] = telegram_ext
+    sys.modules["telegram.error"] = telegram_error
+
+
+_patch_heavy_imports()
+
+from telegram.error import BadRequest
+
+import main
+
+
+class TestSendMenu(unittest.IsolatedAsyncioTestCase):
+    @patch("main.get_menu_text")
+    @patch("main.build_keyboard")
+    async def test_send_menu_callback_query(
+        self, mock_build_keyboard, mock_get_menu_text
+    ):
+        mock_get_menu_text.return_value = "Test Menu Text"
+        mock_build_keyboard.return_value = MagicMock()
+
+        update = MagicMock()
+        update.callback_query = AsyncMock()
+        update.message = None
+
+        await main.send_menu(update, "test_menu_id")
+
+        mock_get_menu_text.assert_called_once_with("test_menu_id")
+        mock_build_keyboard.assert_called_once_with("test_menu_id")
+        update.callback_query.answer.assert_awaited_once()
+        update.callback_query.edit_message_text.assert_awaited_once_with(
+            "Test Menu Text",
+            reply_markup=mock_build_keyboard.return_value,
+            parse_mode="HTML",
+            disable_web_page_preview=True,
+        )
+
+    @patch("main.get_menu_text")
+    @patch("main.build_keyboard")
+    async def test_send_menu_message(self, mock_build_keyboard, mock_get_menu_text):
+        mock_get_menu_text.return_value = "Test Menu Text"
+        mock_build_keyboard.return_value = MagicMock()
+
+        update = MagicMock()
+        update.callback_query = None
+        update.message = AsyncMock()
+
+        await main.send_menu(update, "test_menu_id")
+
+        mock_get_menu_text.assert_called_once_with("test_menu_id")
+        mock_build_keyboard.assert_called_once_with("test_menu_id")
+        update.message.reply_text.assert_awaited_once_with(
+            "Test Menu Text",
+            reply_markup=mock_build_keyboard.return_value,
+            parse_mode="HTML",
+            disable_web_page_preview=True,
+        )
+
+    @patch("main.get_menu_text")
+    @patch("main.build_keyboard")
+    async def test_send_menu_callback_query_ignores_not_modified(
+        self, mock_build_keyboard, mock_get_menu_text
+    ):
+        mock_get_menu_text.return_value = "Test Menu Text"
+        mock_build_keyboard.return_value = MagicMock()
+
+        update = MagicMock()
+        update.callback_query = AsyncMock()
+        update.callback_query.edit_message_text.side_effect = BadRequest(
+            "Message is not modified"
+        )
+        update.message = None
+
+        # Should not raise exception
+        await main.send_menu(update, "test_menu_id")
+
+        update.callback_query.edit_message_text.assert_awaited_once()
+
+    @patch("main.get_menu_text")
+    @patch("main.build_keyboard")
+    async def test_send_menu_callback_query_raises_other_bad_request(
+        self, mock_build_keyboard, mock_get_menu_text
+    ):
+        mock_get_menu_text.return_value = "Test Menu Text"
+        mock_build_keyboard.return_value = MagicMock()
+
+        update = MagicMock()
+        update.callback_query = AsyncMock()
+        update.callback_query.edit_message_text.side_effect = BadRequest("Other error")
+        update.message = None
+
+        # Should raise exception
+        with self.assertRaises(BadRequest) as context:
+            await main.send_menu(update, "test_menu_id")
+
+        self.assertIn("Other error", str(context.exception))
+        update.callback_query.edit_message_text.assert_awaited_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** `main.py` was missing tests for the `send_menu` handler which orchestrates keyboard assembly and bot response editing/sending. This addresses the testing gap for a critical interaction point in the bot.
📊 **Coverage:** The new test file (`tests/test_main_send_menu.py`) fully covers the `send_menu` function. It tests:
  - Both branches (when invoked from a `callback_query` and when invoked from a standard `message`).
  - Handling of the expected `BadRequest("Message is not modified")` which is safely ignored.
  - Verification that other, unexpected `BadRequest` errors are properly propagated.
✨ **Result:** Test coverage and reliability of the `main.py` menu sending logic are significantly improved, safeguarding against future regressions.

---
*PR created automatically by Jules for task [17156202397408120464](https://jules.google.com/task/17156202397408120464) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only adds tests and updates PR documentation; no production logic changes.
> 
> **Overview**
> Adds a new `tests/test_main_send_menu.py` suite that stubs Telegram imports and unit-tests `main.send_menu` for both `callback_query` and `message` invocation paths, including *ignoring* `BadRequest("Message is not modified")` while *propagating* other `BadRequest` errors.
> 
> Updates `pr_description.md` to reflect the new `send_menu` test coverage (replacing the prior description about `create_title` validation tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 964dc06b59134c2326ee5d258493162639f18333. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->