### PR TITLE
🧹 [code health improvement] Remove unused imports in AssetRegistry

### DIFF
--- a/pipeline/metadata/registry.py
+++ b/pipeline/metadata/registry.py
@@ -19,11 +19,8 @@ File layout convention::
 Each file must contain a valid ``Asset.from_dict()``-compatible JSON object.
 """
 
-from __future__ import annotations
-
 import json
 import logging
-import os
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -53,7 +50,9 @@ class AssetRegistry:
     """
 
     def __init__(self, source_dir: Optional[str] = None) -> None:
-        self._source_dir = Path(source_dir).resolve() if source_dir else _DEFAULT_SOURCE_DIR
+        self._source_dir = (
+            Path(source_dir).resolve() if source_dir else _DEFAULT_SOURCE_DIR
+        )
         self._assets: Dict[str, Asset] = {}
         self._load()
 
@@ -79,7 +78,9 @@ class AssetRegistry:
             except Exception as exc:
                 logger.error("Failed to load asset from %s: %s", path, exc)
 
-        logger.info("AssetRegistry: loaded %d asset(s) from %s", loaded, self._source_dir)
+        logger.info(
+            "AssetRegistry: loaded %d asset(s) from %s", loaded, self._source_dir
+        )
 
     def reload(self) -> None:
         """Clear and reload all assets from disk."""


### PR DESCRIPTION
🎯 **What:** Removed `from __future__ import annotations` and `import os` in `pipeline/metadata/registry.py` and ran standard formatting.
💡 **Why:** The `annotations` import is unnecessary in Python 3.12 without forward references, and `os` was completely unused. Removing them removes unnecessary noise and aligns with codebase health practices.
✅ **Verification:** Verified via `ruff check --fix`, formatted with `isort` and `black`, and ran the full unit test suite, confirming no regressions.
✨ **Result:** Cleaned up code with improved formatting and no unused imports.

---
*PR created automatically by Jules for task [6250084640547873629](https://jules.google.com/task/6250084640547873629) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import and formatting-only changes in a metadata loader with no logic or API changes.
> 
> **Overview**
> **`pipeline/metadata/registry.py`** drops unused imports (`from __future__ import annotations` and `import os`) and applies minor formatting (line breaks for long assignments and log calls). Registry behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef10cbf4e9438e2d89d6ffdf64c7ae9e00a2b4f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->