### PR TITLE
🧪 [testing improvement description] Add tests for Asset is_animation_compatible

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -43,7 +43,4 @@
 **Action:** Always check the exact attributes of dataclasses by reading their definition file directly rather than relying on `__init__.py` docstrings which might be slightly out of sync. Use grep and read_file aggressively.
 ## 2024-05-28 - Add tests for Asset.is_animation_compatible
 **Learning:** Testing simple pure functions like list inclusion on Dataclasses can be done elegantly using helper methods to mock the dataclasses rapidly. Test isolation is ensured by instantiating new assets in each test method.
-**Action:** Created  to add missing tests for  method covering all key logical branching of the condition .
-## 2024-05-28 - Add tests for Asset.is_animation_compatible
-**Learning:** Testing simple pure functions like list inclusion on Dataclasses can be done elegantly using helper methods to mock the dataclasses rapidly. Test isolation is ensured by instantiating new assets in each test method.
 **Action:** Created `tests/test_pipeline_asset_model_asset.py` to add missing tests for `pipeline.asset_model.asset.Asset.is_animation_compatible` method covering all key logical branching of the condition `not list or item in list`.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,9 @@
 ## 2024-05-19 - Added tests for pipeline.motion_presets
 **Learning:** Found that the implementation for motion presets was spread between `pipeline/motion_presets/__init__.py`, `pipeline/motion_presets/preset.py`, and `pipeline/motion_presets/catalog.py`. Discovered that `MotionPreset` has `duration_ms` instead of `duration` through test failures.
 **Action:** Always check the exact attributes of dataclasses by reading their definition file directly rather than relying on `__init__.py` docstrings which might be slightly out of sync. Use grep and read_file aggressively.
+## 2024-05-28 - Add tests for Asset.is_animation_compatible
+**Learning:** Testing simple pure functions like list inclusion on Dataclasses can be done elegantly using helper methods to mock the dataclasses rapidly. Test isolation is ensured by instantiating new assets in each test method.
+**Action:** Created  to add missing tests for  method covering all key logical branching of the condition .
+## 2024-05-28 - Add tests for Asset.is_animation_compatible
+**Learning:** Testing simple pure functions like list inclusion on Dataclasses can be done elegantly using helper methods to mock the dataclasses rapidly. Test isolation is ensured by instantiating new assets in each test method.
+**Action:** Created `tests/test_pipeline_asset_model_asset.py` to add missing tests for `pipeline.asset_model.asset.Asset.is_animation_compatible` method covering all key logical branching of the condition `not list or item in list`.

--- a/tests/test_pipeline_asset_model_asset.py
+++ b/tests/test_pipeline_asset_model_asset.py
@@ -1,0 +1,42 @@
+import unittest
+
+from pipeline.asset_model.asset import Asset, CATEGORY_LETTER, THEME_NEON, FORMAT_PNG
+
+class TestAsset(unittest.TestCase):
+
+    def _create_asset(self, animation_compatible_presets=None):
+        kwargs = {
+            "id": "test_asset",
+            "name": "Test Asset",
+            "category": CATEGORY_LETTER,
+            "theme": THEME_NEON,
+            "source_format": FORMAT_PNG,
+            "source_path": "test.png",
+            "width": 100,
+            "height": 100,
+        }
+        if animation_compatible_presets is not None:
+            kwargs["animation_compatible_presets"] = animation_compatible_presets
+
+        return Asset(**kwargs)
+
+    def test_is_animation_compatible_empty_presets(self):
+        """When animation_compatible_presets is empty, it should return True for any preset."""
+        asset = self._create_asset(animation_compatible_presets=[])
+        self.assertTrue(asset.is_animation_compatible("any_preset"))
+        self.assertTrue(asset.is_animation_compatible("another_preset"))
+
+    def test_is_animation_compatible_preset_in_list(self):
+        """When preset_id is in animation_compatible_presets, it should return True."""
+        asset = self._create_asset(animation_compatible_presets=["allowed_preset1", "allowed_preset2"])
+        self.assertTrue(asset.is_animation_compatible("allowed_preset1"))
+        self.assertTrue(asset.is_animation_compatible("allowed_preset2"))
+
+    def test_is_animation_compatible_preset_not_in_list(self):
+        """When preset_id is not in animation_compatible_presets, it should return False."""
+        asset = self._create_asset(animation_compatible_presets=["allowed_preset1", "allowed_preset2"])
+        self.assertFalse(asset.is_animation_compatible("unallowed_preset"))
+        self.assertFalse(asset.is_animation_compatible("another_unallowed"))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for the `is_animation_compatible` method in the `pipeline.asset_model.asset.Asset` dataclass.
📊 **Coverage:** The new tests cover all scenarios:
  1. When `animation_compatible_presets` is empty (returns True for any preset).
  2. When the `preset_id` is present in `animation_compatible_presets` (returns True).
  3. When the `preset_id` is not present in `animation_compatible_presets` (returns False).
✨ **Result:** Increased test coverage and reliability for the asset pipeline by ensuring the compatibility logic behaves precisely as expected without regressions.

---
*PR created automatically by Jules for task [4091338843758525429](https://jules.google.com/task/4091338843758525429) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only coverage plus internal docs; no production logic changes.
> 
> **Overview**
> Adds **`tests/test_pipeline_asset_model_asset.py`** with unit tests for **`Asset.is_animation_compatible`**: empty `animation_compatible_presets` allows any preset; a non-empty list only allows IDs in that list.
> 
> Also appends Jules learning notes to **`.jules/bolt.md`** about how those tests were written (the diff includes a **duplicated** 2024-05-28 entry that could be deduplicated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e8bf474c19d0250bb96f16518309acea0c3b79c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for asset animation compatibility validation, including scenarios for empty preset lists, matching presets, and non-matching presets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FriskyDevelopments/stixmagic-bot/pull/204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->