### PR TITLE
🧪 [Add AssetCatalog by_preset test coverage]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -42,6 +42,6 @@
 **Learning:** Found that the implementation for motion presets was spread between `pipeline/motion_presets/__init__.py`, `pipeline/motion_presets/preset.py`, and `pipeline/motion_presets/catalog.py`. Discovered that `MotionPreset` has `duration_ms` instead of `duration` through test failures.
 **Action:** Always check the exact attributes of dataclasses by reading their definition file directly rather than relying on `__init__.py` docstrings which might be slightly out of sync. Use grep and read_file aggressively.
 
-## $(date +%Y-%m-%d) - AssetCatalog `by_preset` Test Coverage
+## 2026-05-28 - AssetCatalog `by_preset` Test Coverage
 **Learning:** Verified the standard approach for mocking an internal data class (`Asset`) when isolating a class module test.
 **Action:** Added `tests/test_pipeline_metadata_init.py` with comprehensive unit tests for `AssetCatalog.by_preset`, verifying correct behaviors for matched presets, mismatched presets, empty catalogs, and implicit wildcard mappings.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,7 @@
 ## 2024-05-19 - Added tests for pipeline.motion_presets
 **Learning:** Found that the implementation for motion presets was spread between `pipeline/motion_presets/__init__.py`, `pipeline/motion_presets/preset.py`, and `pipeline/motion_presets/catalog.py`. Discovered that `MotionPreset` has `duration_ms` instead of `duration` through test failures.
 **Action:** Always check the exact attributes of dataclasses by reading their definition file directly rather than relying on `__init__.py` docstrings which might be slightly out of sync. Use grep and read_file aggressively.
+
+## $(date +%Y-%m-%d) - AssetCatalog `by_preset` Test Coverage
+**Learning:** Verified the standard approach for mocking an internal data class (`Asset`) when isolating a class module test.
+**Action:** Added `tests/test_pipeline_metadata_init.py` with comprehensive unit tests for `AssetCatalog.by_preset`, verifying correct behaviors for matched presets, mismatched presets, empty catalogs, and implicit wildcard mappings.

--- a/tests/test_pipeline_metadata_init.py
+++ b/tests/test_pipeline_metadata_init.py
@@ -1,0 +1,74 @@
+import unittest
+import tempfile
+
+from pipeline.metadata import AssetCatalog
+from pipeline.asset_model.asset import Asset, CATEGORY_LETTER, THEME_NEON, FORMAT_PNG
+
+class TestAssetCatalog(unittest.TestCase):
+    def setUp(self):
+        # We don't need a real file for these tests, just the in-memory catalog
+        self.catalog = AssetCatalog(path="dummy_path.json", auto_load=False)
+
+    def test_by_preset_empty_catalog(self):
+        """Test by_preset with an empty catalog returns an empty list."""
+        self.assertEqual(self.catalog.by_preset("preset1"), [])
+
+    def test_by_preset_mismatch(self):
+        """Test by_preset with a catalog where no assets match the preset."""
+        asset1 = Asset(
+            id="asset1",
+            name="Asset 1",
+            category=CATEGORY_LETTER,
+            theme=THEME_NEON,
+            source_format=FORMAT_PNG,
+            source_path="dummy.png",
+            width=100,
+            height=100,
+            transparent_background=True,
+            animation_compatible_presets=["preset1", "preset2"],
+            export_targets=[],
+        )
+        self.catalog.add(asset1)
+
+        # preset3 is not in animation_compatible_presets
+        self.assertEqual(self.catalog.by_preset("preset3"), [])
+
+    def test_by_preset_match(self):
+        """Test by_preset with a catalog where an asset matches the preset."""
+        asset1 = Asset(
+            id="asset1",
+            name="Asset 1",
+            category=CATEGORY_LETTER,
+            theme=THEME_NEON,
+            source_format=FORMAT_PNG,
+            source_path="dummy.png",
+            width=100,
+            height=100,
+            transparent_background=True,
+            animation_compatible_presets=["preset1", "preset2"],
+            export_targets=[],
+        )
+        self.catalog.add(asset1)
+
+        # preset1 is in animation_compatible_presets
+        self.assertEqual(self.catalog.by_preset("preset1"), [asset1])
+
+    def test_by_preset_empty_compatible_presets(self):
+        """Test by_preset when an asset has empty animation_compatible_presets (compatible with all)."""
+        asset1 = Asset(
+            id="asset1",
+            name="Asset 1",
+            category=CATEGORY_LETTER,
+            theme=THEME_NEON,
+            source_format=FORMAT_PNG,
+            source_path="dummy.png",
+            width=100,
+            height=100,
+            transparent_background=True,
+            animation_compatible_presets=[], # empty list means compatible with all
+            export_targets=[],
+        )
+        self.catalog.add(asset1)
+
+        # should match any preset
+        self.assertEqual(self.catalog.by_preset("any_preset"), [asset1])

--- a/tests/test_pipeline_metadata_init.py
+++ b/tests/test_pipeline_metadata_init.py
@@ -1,8 +1,7 @@
 import unittest
-import tempfile
 
 from pipeline.metadata import AssetCatalog
-from pipeline.asset_model.asset import Asset, CATEGORY_LETTER, THEME_NEON, FORMAT_PNG
+from pipeline.asset_model import Asset, AssetCategory, AssetTheme, SourceFormat
 
 class TestAssetCatalog(unittest.TestCase):
     def setUp(self):
@@ -18,9 +17,9 @@ class TestAssetCatalog(unittest.TestCase):
         asset1 = Asset(
             id="asset1",
             name="Asset 1",
-            category=CATEGORY_LETTER,
-            theme=THEME_NEON,
-            source_format=FORMAT_PNG,
+            category=AssetCategory.LETTER,
+            theme=AssetTheme.NEON,
+            source_format=SourceFormat.PNG,
             source_path="dummy.png",
             width=100,
             height=100,
@@ -38,9 +37,9 @@ class TestAssetCatalog(unittest.TestCase):
         asset1 = Asset(
             id="asset1",
             name="Asset 1",
-            category=CATEGORY_LETTER,
-            theme=THEME_NEON,
-            source_format=FORMAT_PNG,
+            category=AssetCategory.LETTER,
+            theme=AssetTheme.NEON,
+            source_format=SourceFormat.PNG,
             source_path="dummy.png",
             width=100,
             height=100,
@@ -58,9 +57,9 @@ class TestAssetCatalog(unittest.TestCase):
         asset1 = Asset(
             id="asset1",
             name="Asset 1",
-            category=CATEGORY_LETTER,
-            theme=THEME_NEON,
-            source_format=FORMAT_PNG,
+            category=AssetCategory.LETTER,
+            theme=AssetTheme.NEON,
+            source_format=SourceFormat.PNG,
             source_path="dummy.png",
             width=100,
             height=100,


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for `AssetCatalog.by_preset` method in `pipeline/metadata/__init__.py`. 
📊 **Coverage:** Added test cases for an empty catalog, mismatched preset, matched preset, and assets that define themselves as compatible with all presets.
✨ **Result:** Improved pipeline asset retrieval reliability and test robustness for edge cases.

---
*PR created automatically by Jules for task [16370767609449827754](https://jules.google.com/task/16370767609449827754) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and documentation changes with no changes to pipeline or API behavior.
> 
> **Overview**
> Adds **unit tests** for `AssetCatalog.by_preset` in a new `tests/test_pipeline_metadata_init.py`, using in-memory catalogs (`auto_load=False`) and real `Asset` instances.
> 
> Coverage includes an **empty catalog**, a **preset not listed** on an asset, a **listed preset match**, and assets with **empty `animation_compatible_presets`** (treated as compatible with any preset). A short **`.jules/bolt.md`** note records the testing pattern; **no production code** changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83a2b1b8e07b0e419c63387fb10fb587d6c3840a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->