### PR TITLE
🧪 [testing improvement] Add tests for source_path_to_id

### DIFF
--- a/tests/test_pipeline_exporters_init.py
+++ b/tests/test_pipeline_exporters_init.py
@@ -1,0 +1,28 @@
+import unittest
+from pipeline.exporters import source_path_to_id
+
+class TestSourcePathToId(unittest.TestCase):
+    def test_basic_filename(self):
+        self.assertEqual(source_path_to_id("file.txt"), "file")
+
+    def test_path_with_directory(self):
+        self.assertEqual(source_path_to_id("/path/to/my_image.png"), "my_image")
+        self.assertEqual(source_path_to_id("path/to/another_file.jpg"), "another_file")
+
+    def test_file_without_extension(self):
+        self.assertEqual(source_path_to_id("filename_only"), "filename_only")
+        self.assertEqual(source_path_to_id("/path/to/filename_only"), "filename_only")
+
+    def test_file_with_multiple_dots(self):
+        self.assertEqual(source_path_to_id("archive.tar.gz"), "archive.tar")
+        self.assertEqual(source_path_to_id("/path/to/my.awesome.file.txt"), "my.awesome.file")
+
+    def test_hidden_file(self):
+        self.assertEqual(source_path_to_id(".hidden_file"), ".hidden_file")
+        self.assertEqual(source_path_to_id("/path/to/.hidden"), ".hidden")
+
+    def test_empty_string(self):
+        self.assertEqual(source_path_to_id(""), "")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** Tests were missing for `source_path_to_id` inside `pipeline/exporters/__init__.py`. This commit introduces unit tests to fill that gap.
📊 **Coverage:** Evaluated a full suite of scenarios, including: base file names, file paths combined with directories, file paths without an extension, files with a double/nested extension (like `tar.gz`), hidden dot files, and completely empty strings.
✨ **Result:** Enhanced the reliability of `source_path_to_id` across edge cases and prevented regressions related to path manipulation operations.

---
*PR created automatically by Jules for task [15644777466251366869](https://jules.google.com/task/15644777466251366869) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or security impact.
> 
> **Overview**
> Adds **`tests/test_pipeline_exporters_init.py`** with `unittest` coverage for **`source_path_to_id`** from `pipeline.exporters`.
> 
> Tests lock in expected slug behavior: basename-only IDs, paths with directories, extensionless names, multi-dot names (only the last segment stripped), hidden dotfiles, and empty input. **No production code changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5da1bd19c56654ce02397d64be9b390e2ee75783. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->