### PR TITLE
🧹 [Code Health] Remove unused os import in AssetRegistry

### DIFF
--- a/pipeline/metadata/registry.py
+++ b/pipeline/metadata/registry.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from pathlib import Path
 from typing import Dict, List, Optional
 


### PR DESCRIPTION
🎯 What: Removed an unused `import os` statement from `pipeline/metadata/registry.py`.
💡 Why: Improves code cleanliness, removes a ruff linting error, and reduces unused dependencies in the module.
✅ Verification: Ran `poetry run ruff check` which confirmed no formatting errors, and ran the unit tests ensuring the removal did not break functionality.
✨ Result: Codebase is cleaner and passes linting checks with no unused imports in the file.

---
*PR created automatically by Jules for task [17778374437526516426](https://jules.google.com/task/17778374437526516426) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No logic or API changes; only deletes an unused import.
> 
> **Overview**
> Removes the unused **`import os`** from `pipeline/metadata/registry.py`. The module already uses **`pathlib.Path`** for paths, so behavior is unchanged—this is a lint/cleanup-only edit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6bf8ef8c8cebfd50b86cd4a4617cbdae24ad033. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->