### PR TITLE
🧹 [code health improvement] Remove unused annotations import

### DIFF
--- a/pipeline/metadata/__init__.py
+++ b/pipeline/metadata/__init__.py
@@ -14,8 +14,6 @@ Usage
 >>> catalog.save()
 """
 
-from __future__ import annotations
-
 import json
 import logging
 import os
@@ -94,7 +92,9 @@ class AssetCatalog:
     offending entry so that a partially valid catalog is still usable).
     """
 
-    def __init__(self, path: str = DEFAULT_CATALOG_PATH, *, auto_load: bool = False) -> None:
+    def __init__(
+        self, path: str = DEFAULT_CATALOG_PATH, *, auto_load: bool = False
+    ) -> None:
         self._path = os.path.abspath(path)
         self._assets: dict[str, Asset] = {}
         if auto_load and os.path.exists(self._path):
@@ -149,7 +149,9 @@ class AssetCatalog:
             except (CatalogValidationError, ValueError, KeyError) as exc:
                 if strict:
                     raise CatalogValidationError(str(exc)) from exc
-                logger.error("Catalog entry [%d] skipped due to validation error: %s", i, exc)
+                logger.error(
+                    "Catalog entry [%d] skipped due to validation error: %s", i, exc
+                )
                 continue
             loaded[asset.id] = asset
 
@@ -205,7 +207,8 @@ class AssetCatalog:
         compatible with *all* presets.
         """
         return [
-            a for a in self._assets.values()
+            a
+            for a in self._assets.values()
             if not a.animation_compatible_presets
             or preset_id in a.animation_compatible_presets
         ]
@@ -213,7 +216,9 @@ class AssetCatalog:
     def search(self, tag: str) -> list[Asset]:
         """Return assets whose tag list contains the given tag (case-insensitive)."""
         tag_lower = tag.lower()
-        return [a for a in self._assets.values() if tag_lower in (t.lower() for t in a.tags)]
+        return [
+            a for a in self._assets.values() if tag_lower in (t.lower() for t in a.tags)
+        ]
 
     def __len__(self) -> int:
         return len(self._assets)


### PR DESCRIPTION
🎯 **What:** Removed the unused `from __future__ import annotations` import from `pipeline/metadata/__init__.py`.
💡 **Why:** Python 3.12 natively supports modern type hints (like `list[dict[str, Any]]` and `dict[str, Asset]`). The `annotations` import is unnecessary and removing it improves code hygiene and reduces clutter without altering behavior.
✅ **Verification:** I manually inspected the file to confirm there were no complex forward references that would require the `__future__` import. I then ran `ruff check` and `black` to ensure no linting or formatting issues were introduced, and ran the full test suite to verify no functionality was broken. I also ensured that no temporary agent scratchpad files (like the `edit_file.py` script) were committed.
✨ **Result:** The codebase is cleaner and adheres strictly to Python 3.12 type hinting capabilities without relying on legacy future imports.

---
*PR created automatically by Jules for task [10356145018981827253](https://jules.google.com/task/10356145018981827253) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No logic changes; only an import removal and Black-style formatting in catalog metadata code.
> 
> **Overview**
> Removes the unused **`from __future__ import annotations`** import from **`pipeline/metadata/__init__.py`**, since the project targets Python 3.12 where built-in generics already work without deferred evaluation.
> 
> The rest of the diff is **formatting only** (line breaks in `__init__`, a `logger.error` call, and list comprehensions in `by_preset` / `search`) with **no behavioral changes**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 302f06d92d0274d5f472e3b1b1f682434a355201. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->