### PR TITLE
🧹 [code health improvement] Prevent false-positive TODO extraction

### DIFF
--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -809,7 +809,7 @@ class TestValidatePacksAsync(unittest.TestCase):
 
         conn.commit.assert_called()
 
-    # ── single-connection guarantee (N+1 fix) ─────────────────
+    # ── single-connection guarantee (N+1 resolution) ─────────────────
 
     def test_get_db_called_exactly_once_for_multiple_packs(self):
         """Only one DB connection opened regardless of the number of packs."""


### PR DESCRIPTION
🎯 What: Replaced 'N+1 fix' with 'N+1 resolution' in a comment in test_api_helpers.py.
💡 Why: The word 'fix' triggered an automated scanning tool, extracting the informational comment as an actionable TODO item.
✅ Verification: The comment logic remains the same, but the keyword 'fix' is removed. Test suite runs show no regressions.
✨ Result: Automated scanners will no longer flag this specific comment as a false positive.

---
*PR created automatically by Jules for task [14236675276265359101](https://jules.google.com/task/14236675276265359101) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change in tests with no effect on production code or test behavior.
> 
> **Overview**
> Updates a section comment in `tests/test_api_helpers.py` for the `_validate_packs_async` single-connection tests: the label **N+1 fix** is renamed to **N+1 resolution** so automated TODO scanners do not treat the word `fix` as actionable work.
> 
> No test logic, assertions, or runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdbec27788ba98bdd5185d3258376e6826a892e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->