### PR TITLE
🧹 [Code Health] Remove unused imports in motion_presets

### DIFF
--- a/pipeline/motion_presets/__init__.py
+++ b/pipeline/motion_presets/__init__.py
@@ -12,23 +12,19 @@ pulse, glow, wobble, bounce, orbit, glitch, sparkle,
 particle_burst, laser_sweep, signal_flash
 """
 
-from __future__ import annotations
-
-from dataclasses import dataclass, field
-from typing import Any
-
-
 # ── Catalog helpers ───────────────────────────────────────────
 # catalog.py and preset.py provide a dict-based preset registry that wraps
 # the dataclass above.  Both APIs are exposed from this package.
 try:
+    from .catalog import PRESETS
+    from .catalog import get_preset as _catalog_get_preset
     from .preset import MotionPreset
-    from .catalog import PRESETS, get_preset as _catalog_get_preset, list_presets as _catalog_list_presets
 
     PRESET_REGISTRY = PRESETS
     BUILTIN_PRESETS = list(PRESETS.values())
 except ImportError:
     pass
+
 
 def get_preset(preset_id: str) -> MotionPreset | None:
     """Return the MotionPreset with the given id, or None if not found."""
@@ -61,7 +57,8 @@ def list_presets(
 
     if category is not None:
         result = [
-            p for p in result
+            p
+            for p in result
             if not p.recommended_categories or category in p.recommended_categories
         ]
     if sticker_safe is not None:
@@ -70,4 +67,3 @@ def list_presets(
         result = [p for p in result if p.overlay_safe is overlay_safe]
 
     return result
-


### PR DESCRIPTION
🎯 **What:** Removed unused imports: `annotations` from `__future__`, as well as `dataclass`, `field`, `Any`, and `list_presets` from `pipeline/motion_presets/__init__.py`.
💡 **Why:** Improves maintainability and code hygiene by removing dead code. Python 3.12 supports the type hint syntax natively so `from __future__ import annotations` is not needed.
✅ **Verification:** Ran formatters (`black`, `isort`), linters (`ruff`), and the full test suite (`python -m unittest discover tests`).
✨ **Result:** A cleaner, lint-free file without unnecessary imports.

---
*PR created automatically by Jules for task [12122164457430791010](https://jules.google.com/task/12122164457430791010) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only cleanup with no logic or API changes to preset lookup or filtering.
> 
> **Overview**
> Cleans up **`pipeline/motion_presets/__init__.py`** by dropping unused imports (`__future__.annotations`, `dataclasses`, `typing.Any`, and the unused `list_presets` catalog alias). The package still re-exports presets via **`PRESETS`**, **`get_preset`**, and **`list_presets`**; only import order and a small list-comprehension formatting tweak differ otherwise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38053cd18e5949590b52775969e0381f2d7dd3ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->