### PR TITLE
🧪 [testing improvement] Add missing tests for AssetCatalog.by_preset

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,6 @@
 ## 2024-05-19 - Added tests for pipeline.motion_presets
 **Learning:** Found that the implementation for motion presets was spread between `pipeline/motion_presets/__init__.py`, `pipeline/motion_presets/preset.py`, and `pipeline/motion_presets/catalog.py`. Discovered that `MotionPreset` has `duration_ms` instead of `duration` through test failures.
 **Action:** Always check the exact attributes of dataclasses by reading their definition file directly rather than relying on `__init__.py` docstrings which might be slightly out of sync. Use grep and read_file aggressively.
+## 2026-05-28 - Add missing tests for AssetCatalog.by_preset edge cases
+**Learning:** When testing classes like `AssetCatalog` that perform file IO on instantiation, initialize with `auto_load=False` to avoid hitting the actual filesystem.
+**Action:** Created `tests/test_pipeline_metadata_catalog.py` covering empty catalogs, mismatches, and list checking for `AssetCatalog.by_preset`.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,6 +1,0 @@
-🎯 **What:** `main.py` was missing tests for the `send_menu` handler which orchestrates keyboard assembly and bot response editing/sending. This addresses the testing gap for a critical interaction point in the bot.
-📊 **Coverage:** The new test file (`tests/test_main_send_menu.py`) fully covers the `send_menu` function. It tests:
-  - Both branches (when invoked from a `callback_query` and when invoked from a standard `message`).
-  - Handling of the expected `BadRequest("Message is not modified")` which is safely ignored.
-  - Verification that other, unexpected `BadRequest` errors are properly propagated.
-✨ **Result:** Test coverage and reliability of the `main.py` menu sending logic are significantly improved, safeguarding against future regressions.

--- a/tests/test_pipeline_metadata_catalog.py
+++ b/tests/test_pipeline_metadata_catalog.py
@@ -21,6 +21,10 @@ class TestAssetCatalog(unittest.TestCase):
         empty_catalog = AssetCatalog(auto_load=False)
         self.assertEqual(empty_catalog.by_preset("pulse"), [])
 
+    def test_by_preset_match(self):
+        res = self.catalog.by_preset("pulse")
+        self.assertEqual(res, [self.asset1])
+
     def test_by_preset_mismatch(self):
         # The catalog has asset1 with "pulse" and "fade" presets.
         # "zoom" is a mismatch.

--- a/tests/test_pipeline_metadata_catalog.py
+++ b/tests/test_pipeline_metadata_catalog.py
@@ -1,0 +1,31 @@
+import unittest
+from pipeline.metadata import AssetCatalog
+from pipeline.asset_model.asset import Asset, CATEGORY_LETTER, THEME_NEON, FORMAT_PNG
+
+class TestAssetCatalog(unittest.TestCase):
+    def setUp(self):
+        self.catalog = AssetCatalog(auto_load=False)
+        self.asset1 = Asset(
+            id="letter_a",
+            name="Letter A",
+            category=CATEGORY_LETTER,
+            theme=THEME_NEON,
+            source_format=FORMAT_PNG,
+            source_path="letter_a.png",
+            width=100, height=100,
+            animation_compatible_presets=["pulse", "fade"]
+        )
+        self.catalog.add(self.asset1)
+
+    def test_by_preset_empty_catalog(self):
+        empty_catalog = AssetCatalog(auto_load=False)
+        self.assertEqual(empty_catalog.by_preset("pulse"), [])
+
+    def test_by_preset_mismatch(self):
+        # The catalog has asset1 with "pulse" and "fade" presets.
+        # "zoom" is a mismatch.
+        res = self.catalog.by_preset("zoom")
+        self.assertEqual(res, [])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** Added tests for the `by_preset` method in `AssetCatalog` to verify edge case behavior that was previously untested, specifically ensuring that when the catalog is empty or the requested preset does not match any assets, an empty list is correctly returned.
📊 **Coverage:** The new tests in `tests/test_pipeline_metadata_catalog.py` cover three key scenarios: querying an empty catalog, querying for a preset that does not match any asset in the catalog, and the base case of querying for a preset that does match an asset.
✨ **Result:** Increased test coverage for `pipeline/metadata/__init__.py`, providing a safety net to ensure that asset lookup logic reliably handles empty states or mismatching inputs without raising exceptions or returning invalid data.

---
*PR created automatically by Jules for task [377066729775384750](https://jules.google.com/task/377066729775384750) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes plus doc cleanup; no production logic modified.
> 
> **Overview**
> Adds **`tests/test_pipeline_metadata_catalog.py`** with unit tests for **`AssetCatalog.by_preset`**, using **`auto_load=False`** so tests do not touch the filesystem. Coverage includes an **empty catalog** and a **preset name that no asset lists**—both must return **`[]`**.
> 
> Documents the testing approach in **`.jules/bolt.md`** and **removes** the stale **`pr_description.md`** file (unrelated send-menu PR notes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a13055ac9b4920ba3ee9dd204ea1cc41ed2ba2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->