### PR TITLE
🧹 [code health improvement] Refactor validate_pack into smaller helper functions

### DIFF
--- a/pipeline/packager/__init__.py
+++ b/pipeline/packager/__init__.py
@@ -146,6 +146,30 @@ class PackManifest:
 
 # ── Validation helper ─────────────────────────────────────────
 
+def _validate_pack_assets(pack: PackDefinition, catalog: Any) -> list[str]:
+    """Validate that all assets referenced by the pack exist in the catalog."""
+    errors: list[str] = []
+    for asset_id in pack.included_assets:
+        if catalog.get(asset_id) is None:
+            errors.append(
+                f"Pack '{pack.pack_id}': asset '{asset_id}' not found in catalog."
+            )
+    return errors
+
+
+def _validate_pack_presets(pack: PackDefinition) -> list[str]:
+    """Validate that all motion presets referenced by the pack exist in the registry."""
+    from pipeline.motion_presets import PRESET_REGISTRY
+
+    errors: list[str] = []
+    for preset_id in pack.included_motion_presets:
+        if preset_id not in PRESET_REGISTRY:
+            errors.append(
+                f"Pack '{pack.pack_id}': motion preset '{preset_id}' not found in preset registry."
+            )
+    return errors
+
+
 def validate_pack(
     pack: PackDefinition,
     catalog: Any,  # pipeline.metadata.AssetCatalog
@@ -177,21 +201,10 @@ def validate_pack(
     PackValidationError
         When ``strict=True`` and any referenced asset or preset is not found.
     """
-    from pipeline.motion_presets import PRESET_REGISTRY
-
     errors: list[str] = []
 
-    for asset_id in pack.included_assets:
-        if catalog.get(asset_id) is None:
-            errors.append(
-                f"Pack '{pack.pack_id}': asset '{asset_id}' not found in catalog."
-            )
-
-    for preset_id in pack.included_motion_presets:
-        if preset_id not in PRESET_REGISTRY:
-            errors.append(
-                f"Pack '{pack.pack_id}': motion preset '{preset_id}' not found in preset registry."
-            )
+    errors.extend(_validate_pack_assets(pack, catalog))
+    errors.extend(_validate_pack_presets(pack))
 
     if errors:
         for err in errors:


### PR DESCRIPTION
🎯 **What:** Extracted asset and motion preset validation loops from `validate_pack` in `pipeline/packager/__init__.py` into separate helper functions `_validate_pack_assets` and `_validate_pack_presets`.
💡 **Why:** Improves readability, testability, and maintainability by adhering to the Single Responsibility Principle, reducing the overall complexity of the main function.
✅ **Verification:** Ran the test suite to ensure no new failures were introduced. Ran ruff to ensure formatting and linting pass.
✨ **Result:** `validate_pack` is now a cleaner orchestrator function, making it easier to read and extend with future validation rules.

---
*PR created automatically by Jules for task [2262166997200764508](https://jules.google.com/task/2262166997200764508) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with identical validation logic and error handling; no runtime or API contract changes.
> 
> **Overview**
> **Pack validation** in `pipeline/packager/__init__.py` is split so `validate_pack` only orchestrates: asset checks move to `_validate_pack_assets`, preset checks to `_validate_pack_presets`. The public API, error messages, logging, and `strict` / `PackValidationError` behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7e66afd3de4892a0fd2efe63b972adad536a9c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->