### PR TITLE
🧹 [code health improvement] Prevent false positive TODO extraction

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,6 @@
 ## 2024-05-19 - Added tests for pipeline.motion_presets
 **Learning:** Found that the implementation for motion presets was spread between `pipeline/motion_presets/__init__.py`, `pipeline/motion_presets/preset.py`, and `pipeline/motion_presets/catalog.py`. Discovered that `MotionPreset` has `duration_ms` instead of `duration` through test failures.
 **Action:** Always check the exact attributes of dataclasses by reading their definition file directly rather than relying on `__init__.py` docstrings which might be slightly out of sync. Use grep and read_file aggressively.
+## 2024-05-18 - Fix false positive TODO/FIX markers in test comments
+**Learning:** Automated scanners can be tripped up by words like "fix", even when used in a purely descriptive context (e.g., explaining an "N+1 DB connection fix" that was implemented previously).
+**Action:** Replaced instances of the word "fix" with "optimization" in test suite comments to prevent these tools from surfacing false actionable items while preserving the context.

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -557,7 +557,7 @@ class TestMiniappIntentRoute(ApiTestBase):
 
 # ── _validate_packs_async tests ───────────────────────────────
 #
-# These tests exercise the N+1 DB connection fix introduced in this PR.
+# These tests exercise the N+1 DB connection optimization introduced in this PR.
 # The function opens exactly ONE connection and reuses it across all
 # pack-validation iterations, rather than opening a fresh connection for
 # every UPDATE or DELETE operation.
@@ -809,7 +809,7 @@ class TestValidatePacksAsync(unittest.TestCase):
 
         conn.commit.assert_called()
 
-    # ── single-connection guarantee (N+1 fix) ─────────────────
+    # ── single-connection guarantee (N+1 optimization) ─────────────────
 
     def test_get_db_called_exactly_once_for_multiple_packs(self):
         """Only one DB connection opened regardless of the number of packs."""


### PR DESCRIPTION
🎯 What: Replaced 'fix' with 'optimization' in N+1 database connection comments.
💡 Why: Automated scanners falsely flag 'fix' keywords as actionable TODOs even in descriptive text.
✅ Verification: Ran test suite; no functionality altered.
✨ Result: Clean scanner reports without losing comment context.

---
*PR created automatically by Jules for task [10862996265400061543](https://jules.google.com/task/10862996265400061543) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and internal documentation edits only; no runtime or test behavior changes.
> 
> **Overview**
> Updates **comment-only** wording so automated TODO/FIX scanners stop flagging descriptive mentions of past work.
> 
> In `tests/test_api_helpers.py`, comments around `_validate_packs_async` now say **"N+1 DB connection optimization"** instead of **"fix"**, including the section header for single-connection tests. **`.jules/bolt.md`** adds a short learning note documenting why **"fix"** was swapped for **"optimization"** in test comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fddb05a13be21ce63146fa926c8398e1b92ea256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->