### PR TITLE
🧹 [code health improvement] Rename 'N+1 fix' comment to 'N+1 prevention'

### DIFF
--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -809,7 +809,7 @@ class TestValidatePacksAsync(unittest.TestCase):
 
         conn.commit.assert_called()
 
-    # ── single-connection guarantee (N+1 fix) ─────────────────
+    # ── single-connection guarantee (N+1 prevention) ─────────────────
 
     def test_get_db_called_exactly_once_for_multiple_packs(self):
         """Only one DB connection opened regardless of the number of packs."""


### PR DESCRIPTION
🎯 What (the issue addressed)
The informational comment `# ── single-connection guarantee (N+1 fix) ─────────────────` in `tests/test_api_helpers.py` was being falsely flagged by automated scanners as an actionable TODO/fix item.

💡 Why (maintainability improvement)
Removing the keyword "fix" and changing it to "prevention" stops the false positive from being extracted, keeping the task backlog and codebase clean.

✅ Verification (how safety was confirmed)
Ran the full test suite via `python -m unittest discover tests`. No new test failures were introduced (this is just a comment change).

✨ Result (improvement achieved)
The comment retains its intended descriptive meaning while successfully bypassing automated scanners.

---
*PR created automatically by Jules for task [8997021383666071729](https://jules.google.com/task/8997021383666071729) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change in tests with no production or behavioral impact.
> 
> **Overview**
> Updates a section header comment in `tests/test_api_helpers.py` from **"N+1 fix"** to **"N+1 prevention"** so automated scanners stop treating it as an open fix/TODO. **No runtime or test behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4031595958c5da6dbf24485aaa9701cb207ecff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->