### PR TITLE
🧹 [code health improvement] Extract logic from load in pipeline metadata

### DIFF
--- a/pipeline/metadata/__init__.py
+++ b/pipeline/metadata/__init__.py
@@ -94,7 +94,9 @@ class AssetCatalog:
     offending entry so that a partially valid catalog is still usable).
     """
 
-    def __init__(self, path: str = DEFAULT_CATALOG_PATH, *, auto_load: bool = False) -> None:
+    def __init__(
+        self, path: str = DEFAULT_CATALOG_PATH, *, auto_load: bool = False
+    ) -> None:
         self._path = os.path.abspath(path)
         self._assets: dict[str, Asset] = {}
         if auto_load and os.path.exists(self._path):
@@ -115,9 +117,21 @@ class AssetCatalog:
             invalid entry.  When False (default), log the error and skip the
             offending entry so the rest of the catalog is still available.
         """
+        raw = self._read_catalog_file(strict)
+        if raw is None:
+            return
+
+        self._assets = self._parse_assets(raw, strict)
+        logger.info(
+            "Loaded %d assets from catalog (%d entries in file).",
+            len(self._assets),
+            len(raw),
+        )
+
+    def _read_catalog_file(self, strict: bool) -> list[dict[str, Any]] | None:
         if not os.path.exists(self._path):
             logger.info("Catalog not found at %s — starting empty.", self._path)
-            return
+            return None
         try:
             with open(self._path, encoding="utf-8") as fh:
                 raw: list[dict[str, Any]] = json.load(fh)
@@ -126,10 +140,10 @@ class AssetCatalog:
             if strict:
                 raise CatalogValidationError(msg) from exc
             logger.error(msg)
-            return
+            return None
         except Exception as exc:
             logger.error("Failed to open catalog %s: %s", self._path, exc)
-            return
+            return None
 
         if not isinstance(raw, list):
             msg = (
@@ -139,8 +153,13 @@ class AssetCatalog:
             if strict:
                 raise CatalogValidationError(msg)
             logger.error(msg)
-            return
+            return None
 
+        return raw
+
+    def _parse_assets(
+        self, raw: list[dict[str, Any]], strict: bool
+    ) -> dict[str, Asset]:
         loaded: dict[str, Asset] = {}
         for i, item in enumerate(raw):
             try:
@@ -149,16 +168,12 @@ class AssetCatalog:
             except (CatalogValidationError, ValueError, KeyError) as exc:
                 if strict:
                     raise CatalogValidationError(str(exc)) from exc
-                logger.error("Catalog entry [%d] skipped due to validation error: %s", i, exc)
+                logger.error(
+                    "Catalog entry [%d] skipped due to validation error: %s", i, exc
+                )
                 continue
             loaded[asset.id] = asset
-
-        self._assets = loaded
-        logger.info(
-            "Loaded %d assets from catalog (%d entries in file).",
-            len(self._assets),
-            len(raw),
-        )
+        return loaded
 
     def save(self) -> None:
         """Persist the current in-memory catalog to disk."""
@@ -205,7 +220,8 @@ class AssetCatalog:
         compatible with *all* presets.
         """
         return [
-            a for a in self._assets.values()
+            a
+            for a in self._assets.values()
             if not a.animation_compatible_presets
             or preset_id in a.animation_compatible_presets
         ]
@@ -213,7 +229,9 @@ class AssetCatalog:
     def search(self, tag: str) -> list[Asset]:
         """Return assets whose tag list contains the given tag (case-insensitive)."""
         tag_lower = tag.lower()
-        return [a for a in self._assets.values() if tag_lower in (t.lower() for t in a.tags)]
+        return [
+            a for a in self._assets.values() if tag_lower in (t.lower() for t in a.tags)
+        ]
 
     def __len__(self) -> int:
         return len(self._assets)


### PR DESCRIPTION
🎯 What: Refactored the load method in pipeline/metadata/__init__.py by extracting file I/O into _read_catalog_file and asset parsing into _parse_assets.
💡 Why: The original load method was too long and conflated reading files, JSON parsing, validation, and object instantiation. Extracting these steps makes the code easier to read, test, and maintain.
✅ Verification: Ran the test suite (manifest tests continue to pass) and confirmed no change in external behavior since the exact same validation and logging logic was preserved. Formatted with Black and checked with Ruff.
✨ Result: load method is now clean and delegates to distinct, single-purpose private methods.

---
*PR created automatically by Jules for task [17403292568660679752](https://jules.google.com/task/17403292568660679752) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor of catalog loading with preserved validation, strict mode, and logging; no API or security-sensitive changes.
> 
> **Overview**
> Refactors **`AssetCatalog.load`** in `pipeline/metadata/__init__.py` so it only coordinates loading: it calls new private helpers instead of doing everything inline.
> 
> **`_read_catalog_file`** handles missing files, JSON decode/open failures, and “must be a JSON array” checks, returning `None` when loading should stop (same strict vs log-and-skip behavior as before). **`_parse_assets`** runs per-entry validation and `Asset.from_dict`, building the in-memory map (unchanged strict/skip logic).
> 
> Success logging and assignment to **`self._assets`** stay in **`load`**. Minor Black-style formatting on **`__init__`**, **`by_preset`**, and **`search`** list comprehensions only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8f71e0b3636443f94a688916f06fae8b5a1425f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->