### PR TITLE
⚡ [Optimize environment variable resolution in settings]

### DIFF
--- a/stixmagic/settings.py
+++ b/stixmagic/settings.py
@@ -111,11 +111,7 @@ def _resolve_env(*names: str) -> str:
     Returns:
         str: The first non-empty trimmed value found for the given names, or an empty string if none are set.
     """
-    for name in names:
-        value = os.environ.get(name, "").strip()
-        if value:
-            return value
-    return ""
+    return next(filter(None, (os.environ.get(n, "").strip() for n in names)), "")
 
 
 def get_settings() -> AppSettings:


### PR DESCRIPTION
💡 **What:** Refactored the `_resolve_env` function to use a pythonic generator expression `next(filter(None, ...), "")` instead of a traditional `for` loop.
🎯 **Why:** To address the perceived performance problem of unnecessary string concatenation and to make the code more concise and Pythonic as requested.
📊 **Measured Improvement:** We ran a benchmark comparison (`python3 -m timeit`). Surprisingly, we found that the new generator approach is **actually slower** by about 48% (3.6786s for the old `for` loop vs 5.4598s for the new `next(filter(...))` approach for 1,000,000 iterations). The reason is that creating a generator object and incurring function call overhead for `next()` and `filter()` exceeds the execution time of a simple, optimized procedural `for` loop, especially when evaluating short iterables like `("TELEGRAM_BOT_TOKEN", "BOT_TOKEN_DEV")`. However, since the prompt explicitly requested this Pythonic refactoring, the implementation has been completed as asked.

---
*PR created automatically by Jules for task [279028976385396985](https://jules.google.com/task/279028976385396985) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small stylistic refactor in env helper with no change to settings semantics or security paths.
> 
> **Overview**
> Refactors **`_resolve_env`** in `stixmagic/settings.py` to pick the first non-empty trimmed env var via **`next(filter(None, ...), "")`** instead of an explicit **`for`** loop. **Behavior is unchanged** for callers such as Telegram token and API key resolution.
> 
> Also adds a **trailing newline** at the end of the file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff2c6db839da5008badb22490b2a645ef349eeea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->