### PR TITLE
🧹 [Code Health] Refactor convert_video_to_sticker and extract ffmpeg helper

### DIFF
--- a/src/stickers/media.py
+++ b/src/stickers/media.py
@@ -116,6 +116,20 @@ def convert_to_sticker(file_bytes: io.BytesIO) -> io.BytesIO | None:
 
 # ── Video / GIF pipeline ──────────────────────────────────────
 
+def _run_ffmpeg(tmp_in_path: str, bitrate: str, out_path: str) -> subprocess.CompletedProcess:
+    cmd = [
+        "ffmpeg", "-y", "-i", tmp_in_path,
+        "-vf", "scale='if(gt(iw,ih),512,-2)':'if(gt(iw,ih),-2,512)',fps=30",
+        "-c:v", "libvpx-vp9",
+        "-b:v", bitrate,
+        "-t", "3",
+        "-an",
+        "-pix_fmt", "yuva420p",
+        out_path,
+    ]
+    return subprocess.run(cmd, capture_output=True, timeout=30)
+
+
 def convert_video_to_sticker(file_bytes: io.BytesIO) -> io.BytesIO | None:
     """
     Convert a video / GIF to a VP9 WEBM animated sticker.
@@ -127,6 +141,9 @@ def convert_video_to_sticker(file_bytes: io.BytesIO) -> io.BytesIO | None:
       • yuva420p pixel format (transparency support)
       • File size ≤ 256 KB (bitrate stepped down if needed)
     """
+    tmp_in_path = None
+    tmp_out_path = None
+    tmp_out_path2 = None
     try:
         with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp_in:
             tmp_in.write(file_bytes.getvalue())
@@ -134,20 +151,7 @@ def convert_video_to_sticker(file_bytes: io.BytesIO) -> io.BytesIO | None:
 
         tmp_out_path = tmp_in_path.replace(".mp4", "_out.webm")
 
-        def _run_ffmpeg(bitrate: str, out_path: str) -> subprocess.CompletedProcess:
-            cmd = [
-                "ffmpeg", "-y", "-i", tmp_in_path,
-                "-vf", "scale='if(gt(iw,ih),512,-2)':'if(gt(iw,ih),-2,512)',fps=30",
-                "-c:v", "libvpx-vp9",
-                "-b:v", bitrate,
-                "-t", "3",
-                "-an",
-                "-pix_fmt", "yuva420p",
-                out_path,
-            ]
-            return subprocess.run(cmd, capture_output=True, timeout=30)
-
-        result = _run_ffmpeg("200k", tmp_out_path)
+        result = _run_ffmpeg(tmp_in_path, "200k", tmp_out_path)
 
         if result.returncode != 0:
             logger.error("ffmpeg error: %s", result.stderr.decode()[:500])
@@ -157,24 +161,24 @@ def convert_video_to_sticker(file_bytes: io.BytesIO) -> io.BytesIO | None:
             data = f.read()
 
         if len(data) > 256_000:
-            os.unlink(tmp_out_path)
             tmp_out_path2 = tmp_in_path.replace(".mp4", "_out2.webm")
-            _run_ffmpeg("100k", tmp_out_path2)
+            _run_ffmpeg(tmp_in_path, "100k", tmp_out_path2)
             if os.path.exists(tmp_out_path2):
                 with open(tmp_out_path2, "rb") as f:
                     data = f.read()
-                os.unlink(tmp_out_path2)
-            tmp_out_path = tmp_out_path2
-
-        os.unlink(tmp_in_path)
-        if os.path.exists(tmp_out_path):
-            os.unlink(tmp_out_path)
 
         return io.BytesIO(data)
 
     except Exception as exc:
         logger.error("Video conversion error: %s", exc)
         return None
+    finally:
+        for path in filter(None, [tmp_in_path, tmp_out_path, tmp_out_path2]):
+            if os.path.exists(path):
+                try:
+                    os.unlink(path)
+                except Exception as cleanup_exc:
+                    logger.warning("Failed to remove temporary file %s: %s", path, cleanup_exc)
 
 
 # ── Mask compositing ──────────────────────────────────────────


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Extracted the inline `_run_ffmpeg` function from `convert_video_to_sticker` in `src/stickers/media.py` into a top-level helper function. Grouped all temporary file cleanup into a robust `try...finally` block.

💡 **Why:** How this improves maintainability
The `convert_video_to_sticker` function was too long and complex, mixing video processing execution with complex file cleanup logic. Extracting the execution logic makes the main pipeline clearer, and moving cleanup to a `finally` block eliminates duplicated code and prevents temporary file leaks if exceptions are raised mid-process.

✅ **Verification:** How you confirmed the change is safe
Ran the test suite (via `unittest`) and verified that no new tests failed as a result of the refactoring. The extraction of `_run_ffmpeg` simply altered the scope but not the behavior.

✨ **Result:** The improvement achieved
A significantly shorter, cleaner `convert_video_to_sticker` function with guaranteed, leak-free temporary file cleanup.

---
*PR created automatically by Jules for task [8627511843699612989](https://jules.google.com/task/8627511843699612989) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor of media conversion and temp-file cleanup; no auth, API, or data-model changes.
> 
> **Overview**
> Refactors **`convert_video_to_sticker`** in `src/stickers/media.py` by moving the inline ffmpeg runner to a module-level **`_run_ffmpeg`** helper (same VP9 scale/fps/bitrate command, now takes input path explicitly).
> 
> **Temporary file handling** is consolidated: paths are tracked with `tmp_*` variables initialized to `None`, and a **`finally`** block deletes every created temp file (including the lower-bitrate `_out2.webm` retry), with warnings on cleanup failure instead of scattered `os.unlink` calls on success-only paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a1f987144c01ad03489583e094ef90e85f3cf0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->