### PR TITLE
🧹 [Refactor] Split `init_db` into smaller helper functions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,7 @@
 ## 2024-05-19 - Added tests for pipeline.motion_presets
 **Learning:** Found that the implementation for motion presets was spread between `pipeline/motion_presets/__init__.py`, `pipeline/motion_presets/preset.py`, and `pipeline/motion_presets/catalog.py`. Discovered that `MotionPreset` has `duration_ms` instead of `duration` through test failures.
 **Action:** Always check the exact attributes of dataclasses by reading their definition file directly rather than relying on `__init__.py` docstrings which might be slightly out of sync. Use grep and read_file aggressively.
+
+## 2024-05-24 - Refactored `init_db` in `infra/db.py`
+**Learning:** Refactoring a long, monolithic database initialization function into discrete helper functions (e.g., `_create_tables`, `_create_indices`, `_seed_initial_data`) significantly improves readability and modularity, making future schema updates or data migrations much easier to manage.
+**Action:** Split `init_db` into helper functions and updated `init_db` to orchestrate them sequentially. Verified changes using tests and standard linters.

--- a/infra/db.py
+++ b/infra/db.py
@@ -12,9 +12,7 @@ import time
 
 from stixmagic.settings import get_settings
 
-
 logger = logging.getLogger(__name__)
-
 
 
 def _connect() -> sqlite3.Connection:
@@ -23,40 +21,33 @@ def _connect() -> sqlite3.Connection:
     conn.execute("PRAGMA synchronous=NORMAL;")
     return conn
 
+
 def _db_file() -> str:
     """
     Get the configured SQLite database file path.
-    
+
     Returns:
         str: Filesystem path to the SQLite database as specified by application settings.
     """
     return get_settings().database_path
 
 
-def init_db() -> None:
-    """Create tables if they don't exist."""
-    conn = _connect()
-    c = conn.cursor()
-    c.execute(
-        """
+def _create_tables(c: sqlite3.Cursor) -> None:
+    c.execute("""
         CREATE TABLE IF NOT EXISTS packs (
             id      INTEGER PRIMARY KEY AUTOINCREMENT,
             user_id INTEGER NOT NULL,
             name    TEXT    NOT NULL,
             title   TEXT    NOT NULL
         )
-        """
-    )
-    c.execute(
-        """
+        """)
+    c.execute("""
         CREATE TABLE IF NOT EXISTS user_settings (
             user_id       INTEGER PRIMARY KEY,
             mask_inverted INTEGER DEFAULT 0
         )
-        """
-    )
-    c.execute(
-        """
+        """)
+    c.execute("""
         CREATE TABLE IF NOT EXISTS catalog_packs (
             id          INTEGER PRIMARY KEY AUTOINCREMENT,
             name        TEXT    UNIQUE NOT NULL,
@@ -71,41 +62,61 @@ def init_db() -> None:
             added_at    INTEGER NOT NULL,
             added_by    INTEGER
         )
-        """
-    )
-    c.execute(
-        """
+        """)
+    c.execute("""
         CREATE TABLE IF NOT EXISTS catalog_reactions (
             user_id   INTEGER NOT NULL,
             pack_name TEXT    NOT NULL,
             reaction  TEXT    NOT NULL,
             PRIMARY KEY (user_id, pack_name)
         )
-        """
-    )
+        """)
+
+
+def _create_indices(c: sqlite3.Cursor) -> None:
     # ⚡ Bolt Optimization: Add covering indices for common catalog_search modes
     # Impact: Turns O(N log N) full table scans and temporary B-tree sorting into O(log N) lookups
-    c.execute("CREATE INDEX IF NOT EXISTS idx_catalog_packs_popular ON catalog_packs (public, likes DESC)")
-    c.execute("CREATE INDEX IF NOT EXISTS idx_catalog_packs_trending ON catalog_packs (public, view_count DESC, likes DESC)")
-    c.execute("CREATE INDEX IF NOT EXISTS idx_catalog_packs_new ON catalog_packs (public, added_at DESC)")
+    c.execute(
+        "CREATE INDEX IF NOT EXISTS idx_catalog_packs_popular ON catalog_packs (public, likes DESC)"
+    )
+    c.execute(
+        "CREATE INDEX IF NOT EXISTS idx_catalog_packs_trending ON catalog_packs (public, view_count DESC, likes DESC)"
+    )
+    c.execute(
+        "CREATE INDEX IF NOT EXISTS idx_catalog_packs_new ON catalog_packs (public, added_at DESC)"
+    )
 
     # ⚡ Bolt Optimization: Add index on packs(user_id) for faster lookups
     # Impact: Turns O(N) full table scans on the packs table (which can grow large) into O(log N) lookups for API/bot requests fetching packs for a specific user
     c.execute("CREATE INDEX IF NOT EXISTS idx_packs_user_id ON packs (user_id)")
 
+
+def _seed_initial_data(c: sqlite3.Cursor) -> None:
+    """Seed initial data if necessary. Currently no-op."""
+    pass
+
+
+def init_db() -> None:
+    """Create tables if they don't exist."""
+    conn = _connect()
+    c = conn.cursor()
+    _create_tables(c)
+    _create_indices(c)
+    _seed_initial_data(c)
     conn.commit()
     conn.close()
 
 
 # ── User Settings ─────────────────────────────────────────────
 
+
 def get_mask_inverted(user_id: int) -> bool:
     """
     Determine whether the user's mask display is inverted.
-    
+
     Parameters:
         user_id (int): The user's numeric identifier.
-    
+
     Returns:
         `true` if the user's `mask_inverted` value is 1, `false` otherwise.
     """
@@ -120,7 +131,7 @@ def get_mask_inverted(user_id: int) -> bool:
 def set_mask_inverted(user_id: int, inverted: bool) -> None:
     """
     Set the user's mask inversion setting.
-    
+
     Parameters:
         user_id (int): ID of the user whose setting will be updated.
         inverted (bool): Whether the mask should be inverted (True sets inverted, False clears it).
@@ -138,10 +149,11 @@ def set_mask_inverted(user_id: int, inverted: bool) -> None:
 
 # ── Pack CRUD ─────────────────────────────────────────────────
 
+
 def add_pack(user_id: int, name: str, title: str) -> None:
     """
     Create a new pack record for the specified user in the database.
-    
+
     Parameters:
         user_id (int): ID of the user who owns the pack.
         name (str): Internal name or identifier for the pack.
@@ -160,7 +172,7 @@ def add_pack(user_id: int, name: str, title: str) -> None:
 def delete_pack(user_id: int, name: str) -> None:
     """
     Delete a user's pack identified by its name from the database.
-    
+
     Parameters:
         user_id (int): ID of the user who owns the pack.
         name (str): Pack name to remove.
@@ -175,7 +187,7 @@ def delete_pack(user_id: int, name: str) -> None:
 def get_user_packs(user_id: int) -> list[tuple[str, str]]:
     """
     Retrieve the user's packs as a list of (name, title) tuples.
-    
+
     Returns:
         list[tuple[str, str]]: List of (name, title) tuples for the given user; empty list if the user has no packs.
     """
@@ -190,11 +202,11 @@ def get_user_packs(user_id: int) -> list[tuple[str, str]]:
 def update_pack_title(user_id: int, name: str, title: str) -> None:
     """
     Update the title of a pack belonging to a specific user.
-    
+
     Parameters:
-    	user_id (int): ID of the owner of the pack to update.
-    	name (str): Unique name/identifier of the pack.
-    	title (str): New title to set for the pack.
+        user_id (int): ID of the owner of the pack to update.
+        name (str): Unique name/identifier of the pack.
+        title (str): New title to set for the pack.
     """
     conn = _connect()
     c = conn.cursor()
@@ -208,10 +220,11 @@ def update_pack_title(user_id: int, name: str, title: str) -> None:
 
 # ── User state helpers ────────────────────────────────────────
 
+
 def is_new_user(user_id: int) -> bool:
     """
     Check whether a user is new (has no packs and no stored user settings).
-    
+
     Returns:
         True if the user has not created any packs and has no entry in user_settings, False otherwise.
     """
@@ -222,7 +235,7 @@ def is_new_user(user_id: int) -> bool:
     c.execute(
         "SELECT 1 WHERE EXISTS (SELECT 1 FROM packs WHERE user_id = ?) "
         "OR EXISTS (SELECT 1 FROM user_settings WHERE user_id = ?)",
-        (user_id, user_id)
+        (user_id, user_id),
     )
     result = c.fetchone()
     conn.close()
@@ -230,6 +243,7 @@ def is_new_user(user_id: int) -> bool:
 
 
 # ── Catalog CRUD ──────────────────────────────────────────────
+
 
 def catalog_add_pack(
     name: str,
@@ -240,14 +254,14 @@ def catalog_add_pack(
 ) -> bool:
     """
     Add a new pack to the public catalog.
-    
+
     Parameters:
         name (str): Unique identifier for the pack.
         title (str): Human-readable title for the pack.
         added_by (int): User ID of the account adding the pack.
         description (str): Optional descriptive text for the pack (default: "").
         pack_type (str): Pack category/type (default: "image").
-    
+
     Returns:
         bool: `True` if the pack was inserted, `False` if a pack with the same name already exists.
     """
@@ -272,7 +286,7 @@ def catalog_add_pack(
 def catalog_get_pack(name: str) -> dict | None:
     """
     Retrieve a public catalog pack by its name.
-    
+
     Returns:
         dict: A mapping of the pack's columns (e.g., name, title, description, type, public, safe, likes, dislikes, view_count, added_at, added_by) if a public pack with the given name exists, `None` otherwise.
     """
@@ -293,15 +307,15 @@ def catalog_search(
 ) -> list[dict]:
     """
     Search public catalog packs with optional text filtering, sorting, and pagination.
-    
+
     When sort is "popular", "trending", or "new" results are ordered by likes, view_count then likes, or added_at respectively; for any other sort value the query string is matched against title, name, and description using SQL LIKE. Results include only packs marked public and are limited/offset by the provided pagination parameters.
-    
+
     Parameters:
         query (str): Text to match against title, name, and description when performing a search; ignored for the predefined sort modes.
         sort (str): One of "popular", "trending", "new", or any other value to perform a text search.
         limit (int): Maximum number of results to return.
         offset (int): Number of results to skip before returning.
-    
+
     Returns:
         list[dict]: A list of rows from `catalog_packs` converted to dictionaries (one dict per pack).
     """
@@ -344,11 +358,11 @@ def catalog_search(
 def catalog_count(query: str = "", sort: str = "popular") -> int:
     """
     Count catalog packs that match the given search and visibility criteria.
-    
+
     Parameters:
         query (str): Substring to match against title, name, or description when used (ignored for certain sorts).
         sort (str): If "popular", "trending", or "new", the function counts all public packs and ignores `query`; otherwise it counts public packs whose title, name, or description contain `query`.
-    
+
     Returns:
         int: Total number of matching catalog packs.
     """
@@ -371,7 +385,7 @@ def catalog_count(query: str = "", sort: str = "popular") -> int:
 def catalog_increment_views(name: str) -> None:
     """
     Increment the view count for the catalog pack identified by `name`.
-    
+
     Parameters:
         name (str): The unique catalog pack name whose `view_count` will be incremented in the database.
     """
@@ -386,9 +400,9 @@ def catalog_increment_views(name: str) -> None:
 def catalog_react(user_id: int, pack_name: str, reaction: str) -> dict:
     """
     Toggle a user's like or dislike reaction for a catalog pack.
-    
+
     Adds, removes, or switches the user's reaction and updates the pack's like/dislike counters accordingly.
-    
+
     Returns:
         result (dict): {
             "likes": int — current total likes for the pack,
@@ -463,9 +477,7 @@ def catalog_react(user_id: int, pack_name: str, reaction: str) -> dict:
         current = reaction
 
     conn.commit()
-    c.execute(
-        "SELECT likes, dislikes FROM catalog_packs WHERE name = ?", (pack_name,)
-    )
+    c.execute("SELECT likes, dislikes FROM catalog_packs WHERE name = ?", (pack_name,))
     row = c.fetchone()
     conn.close()
     return {
@@ -478,11 +490,11 @@ def catalog_react(user_id: int, pack_name: str, reaction: str) -> dict:
 def catalog_get_user_reaction(user_id: int, pack_name: str) -> str | None:
     """
     Retrieve the reaction a user has recorded for a catalog pack.
-    
+
     Parameters:
         user_id (int): ID of the user.
         pack_name (str): Name of the catalog pack.
-    
+
     Returns:
         str | None: The reaction string (e.g., 'like' or 'dislike') if a reaction exists, `None` otherwise.
     """


### PR DESCRIPTION
🎯 **What:** Extracted the schema definition, index creation, and initial data seeding steps from the monolithic `init_db()` function into separate helper functions (`_create_tables`, `_create_indices`, and `_seed_initial_data`).

💡 **Why:** The `init_db()` function was growing too long and hard to navigate due to hosting all raw SQL logic within a single block. By breaking it into smaller, logically focused components, the codebase becomes more readable, maintainable, and easier to extend (e.g., when adding migrations or more seed data in the future).

✅ **Verification:** Verified that the logic executed by `init_db()` remains identical to the previous implementation. Ran the complete `unittest` test suite to ensure the refactored initialization still successfully spins up the temporary in-memory database and tests pass as expected.

✨ **Result:** Improved modularity and readability of the `infra/db.py` file without any change in functionality.

---
*PR created automatically by Jules for task [7797974687303842696](https://jules.google.com/task/7797974687303842696) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of initialization order with identical SQL; no auth, data migration, or query logic changes.
> 
> **Overview**
> **`init_db`** in `infra/db.py` no longer inlines all DDL; it opens a connection and calls **`_create_tables`**, **`_create_indices`**, and **`_seed_initial_data`** (currently a no-op placeholder) before commit/close. Table definitions, catalog/packs indexes, and runtime behavior are unchanged—this is structural decomposition for readability and future migrations/seeding.
> 
> A short **Jules bolt** note documents the same refactor pattern. The diff also includes minor docstring/whitespace formatting and a trailing newline on the file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fadbf500ae53b079c0dcfe31027f0333b138c026. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->