### PR TITLE
🧹 [code health improvement] Refactor export_all to simplify orchestration

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,6 @@
 ## 2024-05-19 - Added tests for pipeline.motion_presets
 **Learning:** Found that the implementation for motion presets was spread between `pipeline/motion_presets/__init__.py`, `pipeline/motion_presets/preset.py`, and `pipeline/motion_presets/catalog.py`. Discovered that `MotionPreset` has `duration_ms` instead of `duration` through test failures.
 **Action:** Always check the exact attributes of dataclasses by reading their definition file directly rather than relying on `__init__.py` docstrings which might be slightly out of sync. Use grep and read_file aggressively.
+## 2026-05-28 - Refactor export_all to simplify orchestration
+**Learning:** To prevent automated scanning tools from falsely extracting actionable TODOs, avoid using the word 'fix' in informational code comments (e.g., use 'resolution' or 'mitigation' instead). Also, when extracting code, be mindful of type annotations that might be referenced but not imported in the local context.
+**Action:** Refactored `export_all` in `pipeline/exporters/__init__.py` to extract format-specific logic into helper functions `_export_thumbnail_impl` and `_export_format_impl`.

--- a/pipeline/exporters/__init__.py
+++ b/pipeline/exporters/__init__.py
@@ -299,6 +299,36 @@ def export_thumbnail(
         return None
 
 
+
+def _export_thumbnail_impl(source_path: str, renders_root: str, result) -> None:
+    path = export_thumbnail(source_path, os.path.join(renders_root, "thumbnails"))
+    if path:
+        result.thumbnail = path
+    else:
+        result.errors.append("thumbnail export failed")
+
+def _export_format_impl(
+    fmt: str,
+    source_path: str,
+    preset: MotionPreset,
+    out_dir: str,
+    exporter_fn,
+    result
+) -> None:
+    try:
+        path = exporter_fn(source_path, preset, out_dir)
+    except Exception as exc:
+        result.errors.append(f"{fmt} export raised: {exc}")
+        path = None
+
+    if path:
+        if fmt == "png_sequence":
+            result.png_sequence_dir = path
+        else:
+            setattr(result, fmt, path)
+    else:
+        result.errors.append(f"{fmt} export returned None")
+
 # ── Aggregate exporter ────────────────────────────────────────
 
 def export_all(
@@ -347,31 +377,12 @@ def export_all(
 
     for fmt in formats:
         if fmt == "thumbnail":
-            path = export_thumbnail(source_path, os.path.join(renders_root, "thumbnails"))
-            if path:
-                result.thumbnail = path
-            else:
-                result.errors.append("thumbnail export failed")
-            continue
-
-        if fmt not in _dispatch:
-            result.errors.append(f"unknown format: {fmt!r}")
-            continue
-
-        exporter_fn, out_dir = _dispatch[fmt]
-        try:
-            path = exporter_fn(source_path, preset, out_dir)
-        except Exception as exc:
-            result.errors.append(f"{fmt} export raised: {exc}")
-            path = None
-
-        if path:
-            if fmt == "png_sequence":
-                result.png_sequence_dir = path
-            else:
-                setattr(result, fmt, path)
+            _export_thumbnail_impl(source_path, renders_root, result)
+        elif fmt in _dispatch:
+            exporter_fn, out_dir = _dispatch[fmt]
+            _export_format_impl(fmt, source_path, preset, out_dir, exporter_fn, result)
         else:
-            result.errors.append(f"{fmt} export returned None")
+            result.errors.append(f"unknown format: {fmt!r}")
 
     return result
 


### PR DESCRIPTION
🎯 What: Extracted format-specific exporting logic inside the `export_all` loop into separate helper methods (`_export_thumbnail_impl` and `_export_format_impl`).
💡 Why: This significantly reduces the size and complexity of the `export_all` function, improving its maintainability and readability by abstracting away the explicit try-except block and property-setting code.
✅ Verification: Ran the full test suite (`python -m unittest discover tests`) successfully and ensured the generated dictionary `_dispatch` loop continues to function exactly as before. The changes were also reviewed through the `request_code_review` step.
✨ Result: The orchestration function `export_all` is now much more legible, making further extensions to the export pipeline easier.

---
*PR created automatically by Jules for task [6714910710479541432](https://jules.google.com/task/6714910710479541432) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical extraction of existing logic with no API or dispatch table changes; behavior and error handling paths are preserved.
> 
> **Overview**
> **`export_all`** in `pipeline/exporters/__init__.py` is refactored so the per-format loop only dispatches: thumbnail work goes to **`_export_thumbnail_impl`**, and gif/webp/webm/mov/png_sequence work goes to **`_export_format_impl`** (same try/except, **`ExportResult`** field assignment, and **`png_sequence`** vs **`setattr`** behavior as before). Unknown formats still append the same error string.
> 
> A short **Jules** note was added in **`.jules/bolt.md`** documenting this refactor and a comment-style tip (avoid the word “fix” in informational comments so scanners don’t flag false TODOs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36e293b4d97144ed413e4dd3bc1fe36af0820332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->