### PR TITLE
🧹 [code health improvement] Refine N+1 comment to avoid false positive

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,7 @@
 ## 2024-05-19 - Added tests for pipeline.motion_presets
 **Learning:** Found that the implementation for motion presets was spread between `pipeline/motion_presets/__init__.py`, `pipeline/motion_presets/preset.py`, and `pipeline/motion_presets/catalog.py`. Discovered that `MotionPreset` has `duration_ms` instead of `duration` through test failures.
 **Action:** Always check the exact attributes of dataclasses by reading their definition file directly rather than relying on `__init__.py` docstrings which might be slightly out of sync. Use grep and read_file aggressively.
+
+## 2026-05-28 - Single-connection guarantee (N+1 fix)
+**Learning:** When an informational comment contains the word 'fix', it might be falsely flagged as a TODO by automated scanners. Renaming it to 'optimization' (or something similar depending on context) avoids this while keeping the intent.
+**Action:** Replaced '(N+1 fix)' with '(N+1 optimization)' in tests/test_api_helpers.py comments to stop the false positive.

--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -557,7 +557,7 @@ class TestMiniappIntentRoute(ApiTestBase):
 
 # ── _validate_packs_async tests ───────────────────────────────
 #
-# These tests exercise the N+1 DB connection fix introduced in this PR.
+# These tests exercise the N+1 DB connection optimization introduced in this PR.
 # The function opens exactly ONE connection and reuses it across all
 # pack-validation iterations, rather than opening a fresh connection for
 # every UPDATE or DELETE operation.
@@ -809,7 +809,7 @@ class TestValidatePacksAsync(unittest.TestCase):
 
         conn.commit.assert_called()
 
-    # ── single-connection guarantee (N+1 fix) ─────────────────
+    # ── single-connection guarantee (N+1 optimization) ────────
 
     def test_get_db_called_exactly_once_for_multiple_packs(self):
         """Only one DB connection opened regardless of the number of packs."""


### PR DESCRIPTION
🎯 What: Replaced '(N+1 fix)' with '(N+1 optimization)' in tests/test_api_helpers.py comments.
💡 Why: The word 'fix' was being falsely flagged by an automated TODO/FIXME scanner as an actionable item.
✅ Verification: Ran the test suite to ensure no tests were broken.
✨ Result: Cleaned up the false positive item while retaining the documentation's intent.

---
*PR created automatically by Jules for task [2256470015092493976](https://jules.google.com/task/2256470015092493976) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and comment edits only; no application logic or test assertions changed.
> 
> **Overview**
> Renames documentation wording from **(N+1 fix)** to **(N+1 optimization)** in `tests/test_api_helpers.py` (section header and `_validate_packs_async` test comments) so automated TODO/FIXME scanners stop treating the phrase as actionable work. **No runtime or test behavior changes.**
> 
> Adds a matching Jules learning note in `.jules/bolt.md` describing why **fix** in comments can trigger false positives and that **optimization** preserves intent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34d867f6885da97f754eb9de110182b852870bf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->