### PR TITLE
🧹 [code health improvement] Remove unused annotations import

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,7 @@
 ## 2024-05-19 - Added tests for pipeline.motion_presets
 **Learning:** Found that the implementation for motion presets was spread between `pipeline/motion_presets/__init__.py`, `pipeline/motion_presets/preset.py`, and `pipeline/motion_presets/catalog.py`. Discovered that `MotionPreset` has `duration_ms` instead of `duration` through test failures.
 **Action:** Always check the exact attributes of dataclasses by reading their definition file directly rather than relying on `__init__.py` docstrings which might be slightly out of sync. Use grep and read_file aggressively.
+
+## 2024-05-18 - Remove unused import from pipeline/manifest.py
+**Learning:** Removing unused imports is a straightforward, low-risk change that improves code hygiene.
+**Action:** Removed `from __future__ import annotations` from `pipeline/manifest.py`.

--- a/pipeline/manifest.py
+++ b/pipeline/manifest.py
@@ -56,7 +56,7 @@ The generated JSON has the following top-level structure::
     }
 """
 
-from __future__ import annotations
+
 
 import json
 import logging


### PR DESCRIPTION
🎯 What: Removed the unused `from __future__ import annotations` import from `pipeline/manifest.py`.
💡 Why: The import was not being used and removing it improves code hygiene and readability.
✅ Verification: Ran `poetry run ruff check --fix pipeline/manifest.py` and the full test suite to ensure no regressions.
✨ Result: Cleaner code in `pipeline/manifest.py` without affecting functionality.

---
*PR created automatically by Jules for task [6752883095035055378](https://jules.google.com/task/6752883095035055378) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single unused-import removal with no logic or API changes; verified via lint and tests per the PR description.
> 
> **Overview**
> Removes the unused `from __future__ import annotations` import from `pipeline/manifest.py` as a small hygiene cleanup; runtime behavior and typing in that module are unchanged on Python 3.11+.
> 
> The Jules bolt log (`.jules/bolt.md`) gains a short note documenting this cleanup for future agents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f801257a8b909d9865eba9d4d52d419e2ea1a90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->