### PR TITLE
🧹 [Code Health] Simplify export_all function in pipeline/exporters

### DIFF
--- a/pipeline/exporters/__init__.py
+++ b/pipeline/exporters/__init__.py
@@ -57,12 +57,13 @@ logger = logging.getLogger(__name__)
 
 # ── Output classification ─────────────────────────────────────
 
-STICKER_READY_FORMATS   = {"gif", "webp", "webm"}
-OVERLAY_READY_FORMATS   = {"webm", "mov"}
-PREVIEW_FORMATS         = {"thumbnail"}
+STICKER_READY_FORMATS = {"gif", "webp", "webm"}
+OVERLAY_READY_FORMATS = {"webm", "mov"}
+PREVIEW_FORMATS = {"thumbnail"}
 
 
 # ── Stable result container ───────────────────────────────────
+
 
 @dataclass
 class ExportResult:
@@ -98,13 +99,13 @@ class ExportResult:
 
     asset_id: str
     preset_id: str
-    gif:              Optional[str] = None
-    webp:             Optional[str] = None
-    webm:             Optional[str] = None
-    mov:              Optional[str] = None
+    gif: Optional[str] = None
+    webp: Optional[str] = None
+    webm: Optional[str] = None
+    mov: Optional[str] = None
     png_sequence_dir: Optional[str] = None
-    thumbnail:        Optional[str] = None
-    errors:           list[str]     = field(default_factory=list)
+    thumbnail: Optional[str] = None
+    errors: list[str] = field(default_factory=list)
 
     @property
     def sticker_ready_outputs(self) -> dict[str, str]:
@@ -139,6 +140,7 @@ class ExportResult:
 
 # ── Output filename helper ────────────────────────────────────
 
+
 def _output_name(asset_id: str, preset_id: str, ext: str) -> str:
     """Return a canonical output filename, e.g. ``letter_A_pulse.gif``."""
     return f"{asset_id}_{preset_id}.{ext}"
@@ -156,12 +158,16 @@ def _export_placeholder_file(
     asset_id = source_path_to_id(source_path)
     os.makedirs(output_dir, exist_ok=True)
     out_path = os.path.join(output_dir, _output_name(asset_id, preset_id, ext))
-    _write_placeholder(out_path, f"{format_name} placeholder | asset={source_path} | preset={preset_id}")
+    _write_placeholder(
+        out_path,
+        f"{format_name} placeholder | asset={source_path} | preset={preset_id}",
+    )
     _log_placeholder(exporter_name, out_path)
     return out_path
 
 
 # ── Individual format exporters ───────────────────────────────
+
 
 def export_gif(
     source_path: str,
@@ -171,13 +177,15 @@ def export_gif(
 ) -> str | None:
     """
     Export an animated GIF for the given source and preset.
-    
+
     This is a placeholder exporter: it writes a small marker file at the canonical output path so downstream steps can reference the expected GIF location.
-    
+
     Returns:
         out_path (str | None): Path to the created placeholder GIF file, or `None` if the export failed.
     """
-    return _export_placeholder_file("export_gif", "gif", "GIF", source_path, preset.id, output_dir)
+    return _export_placeholder_file(
+        "export_gif", "gif", "GIF", source_path, preset.id, output_dir
+    )
 
 
 def export_animated_webp(
@@ -188,13 +196,15 @@ def export_animated_webp(
 ) -> str | None:
     """
     Export an animated WebP for the given source using the provided preset.
-    
+
     This is a placeholder exporter: it writes a small text placeholder file named "{asset_id}_{preset_id}.webp" into output_dir and does not perform real frame rendering.
-    
+
     Returns:
         str | None: Path to the created placeholder `.webp` file, or `None` if the export failed.
     """
-    return _export_placeholder_file("export_animated_webp", "webp", "WEBP", source_path, preset.id, output_dir)
+    return _export_placeholder_file(
+        "export_animated_webp", "webp", "WEBP", source_path, preset.id, output_dir
+    )
 
 
 def export_webm(
@@ -205,13 +215,15 @@ def export_webm(
 ) -> str | None:
     """
     Produce a WebM export file for the given source asset and preset (placeholder implementation).
-    
+
     This function writes a small UTF-8 placeholder file named "{asset_id}_{preset_id}.webm" into the specified output directory and logs a warning that the exporter is a placeholder.
-    
+
     Returns:
         out_path (str): Path to the created placeholder WebM file, or `None` if the export failed.
     """
-    return _export_placeholder_file("export_webm", "webm", "WEBM", source_path, preset.id, output_dir)
+    return _export_placeholder_file(
+        "export_webm", "webm", "WEBM", source_path, preset.id, output_dir
+    )
 
 
 def export_mov(
@@ -222,13 +234,15 @@ def export_mov(
 ) -> str | None:
     """
     Write a placeholder MOV export file for the given source and preset and return its path.
-    
+
     This is a stub that writes a text placeholder at the canonical output filename (no real encoding is performed).
-    
+
     Returns:
         out_path (str | None): Filesystem path to the created placeholder MOV file, or `None` if creation failed.
     """
-    return _export_placeholder_file("export_mov", "mov", "MOV", source_path, preset.id, output_dir)
+    return _export_placeholder_file(
+        "export_mov", "mov", "MOV", source_path, preset.id, output_dir
+    )
 
 
 def export_png_sequence(
@@ -241,17 +255,17 @@ def export_png_sequence(
 ) -> str | None:
     """
     Prepare a numbered PNG frame sequence directory for the given source and preset.
-    
+
     This creates (if needed) a directory named "{asset_id}_{preset.id}_frames" inside output_dir, writes a placeholder frame file into that directory, and returns the directory path. Real frame rendering is not implemented; the function currently writes a textual placeholder to indicate where frames would be produced.
-    
+
     Parameters:
-    	source_path (str): Path to the source asset; used to derive the asset id.
-    	preset (MotionPreset): Preset that determines naming; only its `id` is used.
-    	output_dir (str): Root directory where the frames directory will be created.
-    	fps (int): Frames per second that would be used for the sequence.
-    
+        source_path (str): Path to the source asset; used to derive the asset id.
+        preset (MotionPreset): Preset that determines naming; only its `id` is used.
+        output_dir (str): Root directory where the frames directory will be created.
+        fps (int): Frames per second that would be used for the sequence.
+
     Returns:
-    	seq_dir (str | None): Path to the created frames directory, or `None` on failure.
+        seq_dir (str | None): Path to the created frames directory, or `None` on failure.
     """
     asset_id = source_path_to_id(source_path)
     seq_dir = os.path.join(output_dir, f"{asset_id}_{preset.id}_frames")
@@ -301,6 +315,7 @@ def export_thumbnail(
 
 # ── Aggregate exporter ────────────────────────────────────────
 
+
 def export_all(
     asset_id: str,
     source_path: str,
@@ -337,46 +352,66 @@ def export_all(
 
     result = ExportResult(asset_id=asset_id, preset_id=preset.id)
 
-    _dispatch = {
-        "gif":          (export_gif,          os.path.join(renders_root, "gif")),
-        "webp":         (export_animated_webp, os.path.join(renders_root, "webp")),
-        "webm":         (export_webm,          os.path.join(renders_root, "webm")),
-        "mov":          (export_mov,           os.path.join(renders_root, "mov")),
-        "png_sequence": (export_png_sequence,  os.path.join(renders_root, "png_sequences")),
+    dispatch_map = {
+        "gif": (export_gif, os.path.join(renders_root, "gif")),
+        "webp": (export_animated_webp, os.path.join(renders_root, "webp")),
+        "webm": (export_webm, os.path.join(renders_root, "webm")),
+        "mov": (export_mov, os.path.join(renders_root, "mov")),
+        "png_sequence": (
+            export_png_sequence,
+            os.path.join(renders_root, "png_sequences"),
+        ),
     }
 
     for fmt in formats:
-        if fmt == "thumbnail":
-            path = export_thumbnail(source_path, os.path.join(renders_root, "thumbnails"))
-            if path:
-                result.thumbnail = path
-            else:
-                result.errors.append("thumbnail export failed")
-            continue
-
-        if fmt not in _dispatch:
-            result.errors.append(f"unknown format: {fmt!r}")
-            continue
-
-        exporter_fn, out_dir = _dispatch[fmt]
-        try:
-            path = exporter_fn(source_path, preset, out_dir)
-        except Exception as exc:
-            result.errors.append(f"{fmt} export raised: {exc}")
-            path = None
-
-        if path:
-            if fmt == "png_sequence":
-                result.png_sequence_dir = path
-            else:
-                setattr(result, fmt, path)
-        else:
-            result.errors.append(f"{fmt} export returned None")
+        _process_export_format(
+            fmt, source_path, preset, renders_root, dispatch_map, result
+        )
 
     return result
 
 
+def _process_export_format(
+    fmt: str,
+    source_path: str,
+    preset: "MotionPreset",
+    renders_root: str,
+    dispatch_map: dict,
+    result: "ExportResult",
+) -> None:
+    """Process a single export format and update the result."""
+    import os
+
+    if fmt == "thumbnail":
+        path = export_thumbnail(source_path, os.path.join(renders_root, "thumbnails"))
+        if path:
+            result.thumbnail = path
+        else:
+            result.errors.append("thumbnail export failed")
+        return
+
+    if fmt not in dispatch_map:
+        result.errors.append(f"unknown format: {fmt!r}")
+        return
+
+    exporter_fn, out_dir = dispatch_map[fmt]
+    try:
+        path = exporter_fn(source_path, preset, out_dir)
+    except Exception as exc:
+        result.errors.append(f"{fmt} export raised: {exc}")
+        path = None
+
+    if path:
+        if fmt == "png_sequence":
+            result.png_sequence_dir = path
+        else:
+            setattr(result, fmt, path)
+    else:
+        result.errors.append(f"{fmt} export returned None")
+
+
 # ── Internal helpers ──────────────────────────────────────────
+
 
 def source_path_to_id(source_path: str) -> str:
     """Derive a simple asset id slug from a source file path."""


### PR DESCRIPTION
🎯 What: Extracted the format processing logic within the loop of `export_all` into a new, separate helper method `_process_export_format`.
💡 Why: The `export_all` orchestration function was too long and complex. Extracting the loop body improves readability and maintainability.
✅ Verification: Ran formatters, linters, and the full unittest test suite (`python -m unittest discover tests`). Verified that no existing functionality was broken.
✨ Result: Reduced the complexity and length of `export_all`, making the code cleaner and easier to reason about.

---
*PR created automatically by Jules for task [13363607440165040480](https://jules.google.com/task/13363607440165040480) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor of export orchestration with preserved control flow; no auth, data, or public contract changes beyond readability.
> 
> **Overview**
> Refactors **`export_all`** so each requested format is handled by a new **`_process_export_format`** helper instead of an inline loop body, while keeping the same dispatch map (renamed from **`_dispatch`** to **`dispatch_map`**) and **`ExportResult`** updates.
> 
> The rest of the diff is formatting and docstring cleanup (alignment, wrapped calls, parameter indentation) with no intended change to export behavior or the stable **`ExportResult`** API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44d2086081df9403e7a5b890c1246f3fca0fccc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->