### PR TITLE
🧹 [code health improvement] Split adapter registration logic

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,7 @@
 ## 2024-05-19 - Added tests for pipeline.motion_presets
 **Learning:** Found that the implementation for motion presets was spread between `pipeline/motion_presets/__init__.py`, `pipeline/motion_presets/preset.py`, and `pipeline/motion_presets/catalog.py`. Discovered that `MotionPreset` has `duration_ms` instead of `duration` through test failures.
 **Action:** Always check the exact attributes of dataclasses by reading their definition file directly rather than relying on `__init__.py` docstrings which might be slightly out of sync. Use grep and read_file aggressively.
+
+## 2024-05-28 - Split adapter registration logic
+**Learning:** Extracting asset construction logic into a helper function `_build_asset_record` helps separate object instantiation and validation from catalog registration, effectively reducing the length of `register_asset`.
+**Action:** Created `_build_asset_record` to handle object instantiation and validation logic, significantly shortening `register_asset` in `src/adapters/pipeline.py` and modularizing the code.

--- a/src/adapters/pipeline.py
+++ b/src/adapters/pipeline.py
@@ -51,6 +51,7 @@ def _load_pipeline():
     try:
         from pipeline.metadata import AssetCatalog
         from pipeline.asset_model import Asset, AssetCategory, SourceFormat
+
         return AssetCatalog, Asset, AssetCategory, SourceFormat
     except ImportError as exc:
         logger.warning("pipeline_adapter: pipeline package not available – %s", exc)
@@ -58,6 +59,55 @@ def _load_pipeline():
 
 
 # ── Public interface ──────────────────────────────────────────
+
+
+def _build_asset_record(
+    Asset: Any,
+    AssetCategory: Any,
+    SourceFormat: Any,
+    asset_id: str,
+    name: str,
+    category: str,
+    source_path: str,
+    source_format: str | None,
+    theme: str | None,
+    tags: list[str] | None,
+    notes: str,
+) -> Any | None:
+    """Construct an Asset instance from primitive inputs, resolving enums."""
+    # Infer source format from file extension when not supplied
+    if source_format is None:
+        ext = os.path.splitext(source_path)[1].lstrip(".").lower()
+        source_format = ext or "png"
+
+    try:
+        cat = AssetCategory(category)
+        fmt = SourceFormat(source_format)
+    except ValueError as exc:
+        logger.error("pipeline_adapter.register_asset: invalid value – %s", exc)
+        return None
+
+    from pipeline.asset_model import AssetTheme
+
+    resolved_theme = None
+    if theme:
+        try:
+            resolved_theme = AssetTheme(theme)
+        except ValueError:
+            logger.warning(
+                "pipeline_adapter.register_asset: unknown theme %r – ignoring", theme
+            )
+
+    return Asset(
+        id=asset_id,
+        name=name,
+        category=cat,
+        source_format=fmt,
+        source_path=source_path,
+        theme=resolved_theme,
+        tags=tags or [],
+        notes=notes,
+    )
 
 
 def register_asset(
@@ -110,36 +160,22 @@ def register_asset(
 
     AssetCatalog, Asset, AssetCategory, SourceFormat = modules
 
-    # Infer source format from file extension when not supplied
-    if source_format is None:
-        ext = os.path.splitext(source_path)[1].lstrip(".").lower()
-        source_format = ext or "png"
-
-    try:
-        cat  = AssetCategory(category)
-        fmt  = SourceFormat(source_format)
-    except ValueError as exc:
-        logger.error("pipeline_adapter.register_asset: invalid value – %s", exc)
-        return False
-
-    from pipeline.asset_model import AssetTheme
-    resolved_theme = None
-    if theme:
-        try:
-            resolved_theme = AssetTheme(theme)
-        except ValueError:
-            logger.warning("pipeline_adapter.register_asset: unknown theme %r – ignoring", theme)
-
-    asset = Asset(
-        id=asset_id,
-        name=name,
-        category=cat,
-        source_format=fmt,
-        source_path=source_path,
-        theme=resolved_theme,
-        tags=tags or [],
-        notes=notes,
+    asset = _build_asset_record(
+        Asset,
+        AssetCategory,
+        SourceFormat,
+        asset_id,
+        name,
+        category,
+        source_path,
+        source_format,
+        theme,
+        tags,
+        notes,
     )
+
+    if asset is None:
+        return False
 
     catalog = AssetCatalog(auto_load=True)
     catalog.add(asset)
@@ -198,7 +234,9 @@ def generate_exports(
 
     logger.info(
         "pipeline_adapter: running export for asset=%r preset=%r formats=%r",
-        asset_id, preset_id, formats,
+        asset_id,
+        preset_id,
+        formats,
     )
     return export_all(
         asset_id,
@@ -209,7 +247,9 @@ def generate_exports(
     )
 
 
-def get_export_status(asset_id: str, preset_id: str, renders_root: str = "renders") -> dict[str, bool]:
+def get_export_status(
+    asset_id: str, preset_id: str, renders_root: str = "renders"
+) -> dict[str, bool]:
     """
     Check which export formats already exist on disk for an asset+preset pair.
 
@@ -230,10 +270,18 @@ def get_export_status(asset_id: str, preset_id: str, renders_root: str = "render
         _output_name = lambda a, p, e: f"{a}_{p}.{e}"  # noqa: E731
 
     _format_paths = {
-        "gif":       os.path.join(renders_root, "gif",        _output_name(asset_id, preset_id, "gif")),
-        "webp":      os.path.join(renders_root, "webp",       _output_name(asset_id, preset_id, "webp")),
-        "webm":      os.path.join(renders_root, "webm",       _output_name(asset_id, preset_id, "webm")),
-        "mov":       os.path.join(renders_root, "mov",        _output_name(asset_id, preset_id, "mov")),
+        "gif": os.path.join(
+            renders_root, "gif", _output_name(asset_id, preset_id, "gif")
+        ),
+        "webp": os.path.join(
+            renders_root, "webp", _output_name(asset_id, preset_id, "webp")
+        ),
+        "webm": os.path.join(
+            renders_root, "webm", _output_name(asset_id, preset_id, "webm")
+        ),
+        "mov": os.path.join(
+            renders_root, "mov", _output_name(asset_id, preset_id, "mov")
+        ),
         "thumbnail": os.path.join(renders_root, "thumbnails", f"{asset_id}_thumb.png"),
     }
     return {fmt: os.path.exists(path) for fmt, path in _format_paths.items()}


### PR DESCRIPTION
🎯 What: Extracted the core registration logic in register_asset into a private helper function _build_asset_record.
💡 Why: register_asset was getting too long. Splitting out the dictionary/variable building and enum resolution makes the actual register_asset much cleaner, and allows extending or modifying the asset building process without cluttering the pipeline adapter registration.
✅ Verification: Ran poetry run ruff check src/adapters/pipeline.py which passed. Ran poetry run python -m unittest discover tests which only threw pre-existing errors.
✨ Result: Improved maintainability by modularizing the asset building process from the catalog registration step.

---
*PR created automatically by Jules for task [12144845503865668453](https://jules.google.com/task/12144845503865668453) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure structural refactor of optional pipeline adapter registration; catalog write path and validation semantics are preserved.
> 
> **Overview**
> Refactors **`register_asset`** in `src/adapters/pipeline.py` by moving asset construction into a new private helper **`_build_asset_record`**, which handles extension-based format inference, `AssetCategory` / `SourceFormat` validation, optional `AssetTheme` resolution, and `Asset` instantiation. **`register_asset`** now loads the pipeline, calls the helper, and only then adds to the catalog and saves—**behavior is unchanged** on success and failure paths.
> 
> Minor formatting-only tweaks appear in **`generate_exports`** logging and **`get_export_status`** export path dict layout. **`.jules/bolt.md`** documents the refactor pattern for future Jules tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2d5bcf3a6eb8079d67f9640ad1773585407ac2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->