### PR TITLE
🧹 Refactor build_pipeline_manifest into smaller helpers

### DIFF
--- a/pipeline/manifest.py
+++ b/pipeline/manifest.py
@@ -75,9 +75,55 @@ DEFAULT_PACKS_DIR = "packs"
 DEFAULT_RENDERS_ROOT = "renders"
 
 
+def _format_pack_entry(entry: Any, catalog: "AssetCatalog") -> dict[str, Any]:
+    asset = catalog.get(entry.asset_id)
+    return {
+        "asset_id": entry.asset_id,
+        "asset_name": asset.name if asset else entry.asset_id,
+        "asset_category": asset.category.value if asset else "",
+        "preset_id": entry.preset_id,
+        "thumbnail": entry.expected_outputs.get("thumbnail"),
+        "outputs": {
+            fmt: path
+            for fmt, path in entry.expected_outputs.items()
+            if fmt != "thumbnail"
+        },
+    }
+
+
+def _process_pack(
+    pack: "PackDefinition", catalog: "AssetCatalog", renders_root: str
+) -> tuple[dict[str, Any], set[str]] | None:
+    from pipeline.packager import build_pack
+
+    try:
+        pack_manifest = build_pack(
+            pack, catalog, renders_root=renders_root, strict_validation=False
+        )
+    except Exception as exc:
+        logger.error("Skipping pack %r – build_pack failed: %s", pack.pack_id, exc)
+        return None
+
+    entries: list[dict[str, Any]] = []
+    assets_seen: set[str] = set()
+    for entry in pack_manifest.entries:
+        assets_seen.add(entry.asset_id)
+        entries.append(_format_pack_entry(entry, catalog))
+
+    pack_dict = {
+        "pack_id": pack.pack_id,
+        "title": pack.title,
+        "theme": pack.theme,
+        "target_platforms": pack.target_platforms,
+        "export_formats": pack.export_formats,
+        "entries": entries,
+    }
+    return pack_dict, assets_seen
+
+
 def build_pipeline_manifest(
-    packs: list['PackDefinition'],
-    catalog: 'AssetCatalog',
+    packs: list["PackDefinition"],
+    catalog: "AssetCatalog",
     renders_root: str = DEFAULT_RENDERS_ROOT,
 ) -> dict[str, Any]:
     """
@@ -97,52 +143,27 @@ def build_pipeline_manifest(
     dict
         The full manifest as a Python dict.
     """
-    from pipeline.packager import build_pack
-
     manifest_packs: list[dict[str, Any]] = []
     total_assets_seen: set[str] = set()
 
     for pack in packs:
-        try:
-            pack_manifest = build_pack(
-                pack, catalog, renders_root=renders_root, strict_validation=False
-            )
-        except Exception as exc:
-            logger.error("Skipping pack %r – build_pack failed: %s", pack.pack_id, exc)
+        result = _process_pack(pack, catalog, renders_root)
+        if result is None:
             continue
-
-        entries: list[dict[str, Any]] = []
-        for entry in pack_manifest.entries:
-            total_assets_seen.add(entry.asset_id)
-            asset = catalog.get(entry.asset_id)
-            entries.append({
-                "asset_id":       entry.asset_id,
-                "asset_name":     asset.name if asset else entry.asset_id,
-                "asset_category": asset.category.value if asset else "",
-                "preset_id":      entry.preset_id,
-                "thumbnail":      entry.expected_outputs.get("thumbnail"),
-                "outputs": {
-                    fmt: path
-                    for fmt, path in entry.expected_outputs.items()
-                    if fmt != "thumbnail"
-                },
-            })
-
-        manifest_packs.append({
-            "pack_id":         pack.pack_id,
-            "title":           pack.title,
-            "theme":           pack.theme,
-            "target_platforms": pack.target_platforms,
-            "export_formats":  pack.export_formats,
-            "entries":         entries,
-        })
-        logger.info("build_pipeline_manifest: added pack %r (%d entries)", pack.pack_id, len(entries))
+        pack_dict, assets_seen = result
+        total_assets_seen.update(assets_seen)
+        manifest_packs.append(pack_dict)
+        logger.info(
+            "build_pipeline_manifest: added pack %r (%d entries)",
+            pack.pack_id,
+            len(pack_dict["entries"]),
+        )
 
     return {
         "generated_at": datetime.now(timezone.utc).isoformat(),
-        "total_packs":  len(manifest_packs),
+        "total_packs": len(manifest_packs),
         "total_assets": len(total_assets_seen),
-        "packs":        manifest_packs,
+        "packs": manifest_packs,
     }
 
 
@@ -200,7 +221,7 @@ def generate_pipeline_manifest(
             "generate_pipeline_manifest: no pack.json files found under %r", packs_dir
         )
 
-    packs: list['PackDefinition'] = []
+    packs: list["PackDefinition"] = []
     for pack_file in pack_json_files:
         try:
             pack = PackDefinition.from_file(pack_file)
@@ -216,7 +237,9 @@ def generate_pipeline_manifest(
             json.dump(manifest, fh, indent=2)
         logger.info(
             "generate_pipeline_manifest: wrote %d packs / %d unique assets to %s",
-            manifest["total_packs"], manifest["total_assets"], output_path,
+            manifest["total_packs"],
+            manifest["total_assets"],
+            output_path,
         )
     except Exception as exc:
         logger.error("Failed to write manifest to %s: %s", output_path, exc)
@@ -226,6 +249,7 @@ def generate_pipeline_manifest(
 
 if __name__ == "__main__":
     import sys
+
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
     out = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_MANIFEST_PATH
     result = generate_pipeline_manifest(output_path=out)


### PR DESCRIPTION
🎯 **What:** Extracted the inner loop of `build_pipeline_manifest` in `pipeline/manifest.py` into two smaller helper functions: `_format_pack_entry` and `_process_pack`.

💡 **Why:** The original `build_pipeline_manifest` function was too long and complex, handling iteration, validation, dictionary formatting, and manifest accumulation all in one large loop. Breaking it into targeted helpers drastically improves readability, code health, and maintainability by isolating the formatting logic from the orchestration logic.

✅ **Verification:** Validated that the tests specific to `pipeline/manifest.py` (in `tests/test_pipeline_manifest.py`) successfully passed after refactoring, proving that the original behavior is strictly preserved. Code formatting and linting (Black/Ruff) were also successfully executed.

✨ **Result:** A cleaner, modularized manifest builder without any change to outward functionality.

---
*PR created automatically by Jules for task [2918890357080223997](https://jules.google.com/task/2918890357080223997) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure structural refactor in manifest generation with no API or schema changes; risk is low assuming existing manifest tests still pass.
> 
> **Overview**
> **Refactors** `build_pipeline_manifest` in `pipeline/manifest.py` by pulling pack-building and per-entry JSON shaping into `_process_pack` and `_format_pack_entry`, so the main function only loops packs, merges asset IDs, and assembles the top-level manifest.
> 
> **Behavior** is intended to stay the same: each pack still calls `build_pack` with `strict_validation=False`, skips failed packs with the same error log, and produces the same entry fields (asset metadata, thumbnail, non-thumbnail outputs). The diff also includes minor style tweaks (consistent quote style, log/formatting line breaks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82d9ddb7813480ce275b61252961329d9933f5a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->