### PR TITLE
🧹 [code health improvement] Refactor register_asset to improve readability

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,6 @@
 ## 2024-05-19 - Added tests for pipeline.motion_presets
 **Learning:** Found that the implementation for motion presets was spread between `pipeline/motion_presets/__init__.py`, `pipeline/motion_presets/preset.py`, and `pipeline/motion_presets/catalog.py`. Discovered that `MotionPreset` has `duration_ms` instead of `duration` through test failures.
 **Action:** Always check the exact attributes of dataclasses by reading their definition file directly rather than relying on `__init__.py` docstrings which might be slightly out of sync. Use grep and read_file aggressively.
+## 2024-05-28 - [Code Health] Refactor register_asset to improve readability
+**Learning:** Found that `register_asset` was handling multiple responsibilities including parsing arguments, resolving enums, instantiating models, and persisting to disk. This made the function overly long and harder to maintain.
+**Action:** Factored out the parsing/instantiation logic into a private `_build_asset` helper and the persistence logic into a private `_save_to_catalog` helper. This simplifies `register_asset` into a clean orchestrator, improving overall readability and code health.

--- a/src/adapters/pipeline.py
+++ b/src/adapters/pipeline.py
@@ -60,6 +60,58 @@ def _load_pipeline():
 # ── Public interface ──────────────────────────────────────────
 
 
+def _build_asset(
+    Asset: Any,
+    AssetCategory: Any,
+    SourceFormat: Any,
+    asset_id: str,
+    name: str,
+    category: str,
+    source_path: str,
+    source_format: str | None,
+    theme: str | None,
+    tags: list[str] | None,
+    notes: str,
+) -> Any | None:
+    # Infer source format from file extension when not supplied
+    if source_format is None:
+        ext = os.path.splitext(source_path)[1].lstrip(".").lower()
+        source_format = ext or "png"
+
+    try:
+        cat = AssetCategory(category)
+        fmt = SourceFormat(source_format)
+    except ValueError as exc:
+        logger.error("pipeline_adapter.register_asset: invalid value – %s", exc)
+        return None
+
+    from pipeline.asset_model import AssetTheme
+    resolved_theme = None
+    if theme:
+        try:
+            resolved_theme = AssetTheme(theme)
+        except ValueError:
+            logger.warning("pipeline_adapter.register_asset: unknown theme %r – ignoring", theme)
+
+    return Asset(
+        id=asset_id,
+        name=name,
+        category=cat,
+        source_format=fmt,
+        source_path=source_path,
+        theme=resolved_theme,
+        tags=tags or [],
+        notes=notes,
+    )
+
+
+def _save_to_catalog(AssetCatalog: Any, asset: Any) -> None:
+    catalog = AssetCatalog(auto_load=True)
+    catalog.add(asset)
+    catalog.save()
+    logger.info("pipeline_adapter: registered asset %r in catalog", asset.id)
+
+
 def register_asset(
     asset_id: str,
     name: str,
@@ -110,41 +162,23 @@ def register_asset(
 
     AssetCatalog, Asset, AssetCategory, SourceFormat = modules
 
-    # Infer source format from file extension when not supplied
-    if source_format is None:
-        ext = os.path.splitext(source_path)[1].lstrip(".").lower()
-        source_format = ext or "png"
-
-    try:
-        cat  = AssetCategory(category)
-        fmt  = SourceFormat(source_format)
-    except ValueError as exc:
-        logger.error("pipeline_adapter.register_asset: invalid value – %s", exc)
+    asset = _build_asset(
+        Asset,
+        AssetCategory,
+        SourceFormat,
+        asset_id,
+        name,
+        category,
+        source_path,
+        source_format,
+        theme,
+        tags,
+        notes,
+    )
+    if asset is None:
         return False
 
-    from pipeline.asset_model import AssetTheme
-    resolved_theme = None
-    if theme:
-        try:
-            resolved_theme = AssetTheme(theme)
-        except ValueError:
-            logger.warning("pipeline_adapter.register_asset: unknown theme %r – ignoring", theme)
-
-    asset = Asset(
-        id=asset_id,
-        name=name,
-        category=cat,
-        source_format=fmt,
-        source_path=source_path,
-        theme=resolved_theme,
-        tags=tags or [],
-        notes=notes,
-    )
-
-    catalog = AssetCatalog(auto_load=True)
-    catalog.add(asset)
-    catalog.save()
-    logger.info("pipeline_adapter: registered asset %r in catalog", asset_id)
+    _save_to_catalog(AssetCatalog, asset)
     return True
 
 


### PR DESCRIPTION
🎯 **What:** Extracted the asset building logic into `_build_asset` and the persistence logic into `_save_to_catalog` within `src/adapters/pipeline.py`.
💡 **Why:** The `register_asset` function was too long as it was mixing validation, initialization, and persistence. Factoring these out makes `register_asset` much shorter and improves readability by focusing on orchestration.
✅ **Verification:** Ran `ruff` for code formatting, and successfully ran the test suite using `unittest` to ensure that no existing functionality is broken.
✨ **Result:** The function length and complexity of `register_asset` are greatly reduced, leading to a healthier, more maintainable code file.

---
*PR created automatically by Jules for task [15178636064610394118](https://jules.google.com/task/15178636064610394118) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural-only refactor of the optional pipeline adapter with no API or logic changes beyond equivalent logging.
> 
> **Overview**
> Refactors **`register_asset`** in `src/adapters/pipeline.py` by moving validation and model construction into **`_build_asset`** and catalog persistence into **`_save_to_catalog`**, leaving the public function as a short orchestration path (load pipeline → build asset → save).
> 
> Documents the same refactor in **`.jules/bolt.md`**. Public API and control flow are unchanged; the success log now references **`asset.id`** instead of the **`asset_id`** argument (equivalent in normal use).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c87b669809f039401f64d87172cef21c58cf27ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->