### PR TITLE
🧹 [code health improvement] Refactor sticker media conversion for maintainability

### DIFF
--- a/src/stickers/media.py
+++ b/src/stickers/media.py
@@ -116,6 +116,20 @@ def convert_to_sticker(file_bytes: io.BytesIO) -> io.BytesIO | None:
 
 # ── Video / GIF pipeline ──────────────────────────────────────
 
+def _run_ffmpeg(input_path: str, bitrate: str, out_path: str) -> subprocess.CompletedProcess:
+    """Run ffmpeg to convert a video to VP9 WEBM format."""
+    cmd = [
+        "ffmpeg", "-y", "-i", input_path,
+        "-vf", "scale='if(gt(iw,ih),512,-2)':'if(gt(iw,ih),-2,512)',fps=30",
+        "-c:v", "libvpx-vp9",
+        "-b:v", bitrate,
+        "-t", "3",
+        "-an",
+        "-pix_fmt", "yuva420p",
+        out_path,
+    ]
+    return subprocess.run(cmd, capture_output=True, timeout=30)
+
 def convert_video_to_sticker(file_bytes: io.BytesIO) -> io.BytesIO | None:
     """
     Convert a video / GIF to a VP9 WEBM animated sticker.
@@ -128,49 +142,30 @@ def convert_video_to_sticker(file_bytes: io.BytesIO) -> io.BytesIO | None:
       • File size ≤ 256 KB (bitrate stepped down if needed)
     """
     try:
-        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp_in:
-            tmp_in.write(file_bytes.getvalue())
-            tmp_in_path = tmp_in.name
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_in_path = os.path.join(tmpdir, "in.mp4")
+            with open(tmp_in_path, "wb") as f:
+                f.write(file_bytes.getvalue())
 
-        tmp_out_path = tmp_in_path.replace(".mp4", "_out.webm")
+            tmp_out_path = os.path.join(tmpdir, "out.webm")
 
-        def _run_ffmpeg(bitrate: str, out_path: str) -> subprocess.CompletedProcess:
-            cmd = [
-                "ffmpeg", "-y", "-i", tmp_in_path,
-                "-vf", "scale='if(gt(iw,ih),512,-2)':'if(gt(iw,ih),-2,512)',fps=30",
-                "-c:v", "libvpx-vp9",
-                "-b:v", bitrate,
-                "-t", "3",
-                "-an",
-                "-pix_fmt", "yuva420p",
-                out_path,
-            ]
-            return subprocess.run(cmd, capture_output=True, timeout=30)
+            result = _run_ffmpeg(tmp_in_path, "200k", tmp_out_path)
 
-        result = _run_ffmpeg("200k", tmp_out_path)
+            if result.returncode != 0:
+                logger.error("ffmpeg error: %s", result.stderr.decode()[:500])
+                return None
 
-        if result.returncode != 0:
-            logger.error("ffmpeg error: %s", result.stderr.decode()[:500])
-            return None
+            with open(tmp_out_path, "rb") as f:
+                data = f.read()
 
-        with open(tmp_out_path, "rb") as f:
-            data = f.read()
+            if len(data) > 256_000:
+                tmp_out_path2 = os.path.join(tmpdir, "out2.webm")
+                _run_ffmpeg(tmp_in_path, "100k", tmp_out_path2)
+                if os.path.exists(tmp_out_path2):
+                    with open(tmp_out_path2, "rb") as f:
+                        data = f.read()
 
-        if len(data) > 256_000:
-            os.unlink(tmp_out_path)
-            tmp_out_path2 = tmp_in_path.replace(".mp4", "_out2.webm")
-            _run_ffmpeg("100k", tmp_out_path2)
-            if os.path.exists(tmp_out_path2):
-                with open(tmp_out_path2, "rb") as f:
-                    data = f.read()
-                os.unlink(tmp_out_path2)
-            tmp_out_path = tmp_out_path2
-
-        os.unlink(tmp_in_path)
-        if os.path.exists(tmp_out_path):
-            os.unlink(tmp_out_path)
-
-        return io.BytesIO(data)
+            return io.BytesIO(data)
 
     except Exception as exc:
         logger.error("Video conversion error: %s", exc)
@@ -223,13 +218,13 @@ def apply_mask_to_image(
 
 async def async_convert_to_sticker(file_bytes: io.BytesIO) -> io.BytesIO | None:
     """Thread-pool wrapper around convert_to_sticker (non-blocking)."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     return await loop.run_in_executor(None, convert_to_sticker, file_bytes)
 
 
 async def async_convert_video_to_sticker(file_bytes: io.BytesIO) -> io.BytesIO | None:
     """Thread-pool wrapper around convert_video_to_sticker (non-blocking)."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     return await loop.run_in_executor(None, convert_video_to_sticker, file_bytes)
 
 
@@ -239,7 +234,7 @@ async def async_apply_mask_to_image(
     inverted: bool = False,
 ) -> io.BytesIO:
     """Thread-pool wrapper around apply_mask_to_image (non-blocking)."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     return await loop.run_in_executor(
         None, apply_mask_to_image, source_bytes, mask_bytes, inverted
     )


### PR DESCRIPTION
🎯 What:
- Extracted the run_ffmpeg subprocess call from inside convert_video_to_sticker out to the module level.
- Refactored convert_video_to_sticker to utilize tempfile.TemporaryDirectory() rather than manual string generation and os.unlink calls.
- Updated deprecated asyncio.get_event_loop() to asyncio.get_running_loop() across all async wrappers.

💡 Why:
- Defining functions inside other functions unnecessarily pollutes scope and causes redefinition on every function call.
- Manual file cleanup logic is highly prone to failing if exceptions are thrown early, leaving orphaned temp files. Context managers natively guarantee cleanup.
- Modern asyncio requires get_running_loop() inside coroutines to avoid deprecation warnings and future-proof the application.

✅ Verification:
- Tests for convert_video_to_sticker were re-run via test_domain_media.py and passed successfully.
- Code structure verified against existing logic. No semantic behavior changes were introduced.

✨ Result:
- Enhanced maintainability, improved readability, safer cleanup, and modern Python standards compliance.

---
*PR created automatically by Jules for task [2547030485185136878](https://jules.google.com/task/2547030485185136878) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving cleanup and asyncio API updates in non-critical media conversion code; no auth or data-path changes.
> 
> **Overview**
> Refactors sticker **video/GIF → WEBM** conversion in `media.py` without changing the ffmpeg rules (512px scale, 3s cap, VP9, 200k/100k bitrate retry under 256 KB).
> 
> **ffmpeg** invocation moves to a module-level `_run_ffmpeg` helper instead of a nested function recreated on each call. Temp files now live under `tempfile.TemporaryDirectory()` with fixed names under that directory, replacing `NamedTemporaryFile` plus manual `os.unlink` cleanup.
> 
> All three async sticker helpers (`async_convert_to_sticker`, `async_convert_video_to_sticker`, `async_apply_mask_to_image`) switch from deprecated `asyncio.get_event_loop()` to `asyncio.get_running_loop()` when scheduling `run_in_executor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a068a17d99060c2a3b06fc27c044a001fac0f59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->