### PR TITLE
🧹 [code health improvement] Prevent false-positive task extraction from informational comment

### DIFF
--- a/tests/test_api_helpers.py
+++ b/tests/test_api_helpers.py
@@ -809,7 +809,7 @@ class TestValidatePacksAsync(unittest.TestCase):
 
         conn.commit.assert_called()
 
-    # ── single-connection guarantee (N+1 fix) ─────────────────
+    # ── single-connection guarantee (N+1 resolution) ─────────────────
 
     def test_get_db_called_exactly_once_for_multiple_packs(self):
         """Only one DB connection opened regardless of the number of packs."""


### PR DESCRIPTION
The issue flagged an informational comment `single-connection guarantee (N+1 fix)` as an actionable task due to the keyword `fix`. This pull request replaces `fix` with `resolution` in the comment to prevent future task scrapers from generating false positives.

No tests or logic were altered since this was merely a comment rewording. The test suite has been successfully run to guarantee that no existing functionality was broken by this change.

---
*PR created automatically by Jules for task [8134564995253739060](https://jules.google.com/task/8134564995253739060) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change with no logic, API, or security impact.
> 
> **Overview**
> Rewords a section comment in `tests/test_api_helpers.py` from **“N+1 fix”** to **“N+1 resolution”** so automated task scrapers are less likely to treat the word `fix` as an open work item. **No runtime or test behavior changes**—only the comment text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b09b637e93a5508a4e08e6efca637d532b0e81b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->