### PR TITLE
🧹 [code health improvement] Refactor exports generation to use sub-functions

### DIFF
--- a/pipeline/exporters/__init__.py
+++ b/pipeline/exporters/__init__.py
@@ -301,6 +301,30 @@ def export_thumbnail(
 
 # ── Aggregate exporter ────────────────────────────────────────
 
+
+def _process_thumbnail(source_path: str, renders_root: str, result: ExportResult) -> None:
+    path = export_thumbnail(source_path, os.path.join(renders_root, "thumbnails"))
+    if path:
+        result.thumbnail = path
+    else:
+        result.errors.append("thumbnail export failed")
+
+def _process_format(fmt: str, source_path: str, preset: MotionPreset, dispatch_info: tuple, result: ExportResult) -> None:
+    exporter_fn, out_dir = dispatch_info
+    try:
+        path = exporter_fn(source_path, preset, out_dir)
+    except Exception as exc:
+        result.errors.append(f"{fmt} export raised: {exc}")
+        path = None
+
+    if path:
+        if fmt == "png_sequence":
+            result.png_sequence_dir = path
+        else:
+            setattr(result, fmt, path)
+    else:
+        result.errors.append(f"{fmt} export returned None")
+
 def export_all(
     asset_id: str,
     source_path: str,
@@ -347,31 +371,11 @@ def export_all(
 
     for fmt in formats:
         if fmt == "thumbnail":
-            path = export_thumbnail(source_path, os.path.join(renders_root, "thumbnails"))
-            if path:
-                result.thumbnail = path
-            else:
-                result.errors.append("thumbnail export failed")
-            continue
-
-        if fmt not in _dispatch:
+            _process_thumbnail(source_path, renders_root, result)
+        elif fmt not in _dispatch:
             result.errors.append(f"unknown format: {fmt!r}")
-            continue
-
-        exporter_fn, out_dir = _dispatch[fmt]
-        try:
-            path = exporter_fn(source_path, preset, out_dir)
-        except Exception as exc:
-            result.errors.append(f"{fmt} export raised: {exc}")
-            path = None
-
-        if path:
-            if fmt == "png_sequence":
-                result.png_sequence_dir = path
-            else:
-                setattr(result, fmt, path)
         else:
-            result.errors.append(f"{fmt} export returned None")
+            _process_format(fmt, source_path, preset, _dispatch[fmt], result)
 
     return result
 

--- a/src/adapters/pipeline.py
+++ b/src/adapters/pipeline.py
@@ -148,6 +148,26 @@ def register_asset(
     return True
 
 
+
+def _load_export_modules():
+    try:
+        from pipeline.motion_presets import get_preset
+        from pipeline.exporters import export_all
+        return get_preset, export_all
+    except ImportError as exc:
+        logger.warning("pipeline_adapter: pipeline package not available – %s", exc)
+        return None
+
+def _get_preset_for_export(get_preset_fn, preset_id: str):
+    preset = get_preset_fn(preset_id)
+    if preset is None:
+        logger.error(
+            "pipeline_adapter.generate_exports: preset %r not found – skipping export",
+            preset_id,
+        )
+        return None
+    return preset
+
 def generate_exports(
     asset_id: str,
     source_path: str,
@@ -181,19 +201,13 @@ def generate_exports(
         The export result container, or None if the pipeline is unavailable
         or the preset is not found.
     """
-    try:
-        from pipeline.motion_presets import get_preset
-        from pipeline.exporters import export_all
-    except ImportError as exc:
-        logger.warning("pipeline_adapter: pipeline package not available – %s", exc)
+    modules = _load_export_modules()
+    if modules is None:
         return None
+    get_preset, export_all = modules
 
-    preset = get_preset(preset_id)
+    preset = _get_preset_for_export(get_preset, preset_id)
     if preset is None:
-        logger.error(
-            "pipeline_adapter.generate_exports: preset %r not found – skipping export",
-            preset_id,
-        )
         return None
 
     logger.info(


### PR DESCRIPTION
🎯 **What:** Extracted export format looping into sub-functions in export_all and moved lazy-loading/preset-fetching in generate_exports into helper functions.
💡 **Why:** Improves readability, reduces function complexity, and satisfies code health guidelines by delegating multi-format generation to distinct sub-functions.
✅ **Verification:** Ran the full test suite with necessary environment variables and passed `ruff` checks.
✨ **Result:** Cleaner, more modular code in adapters and exporters without any functionality changes.

---
*PR created automatically by Jules for task [10832684513200807288](https://jules.google.com/task/10832684513200807288) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor only; export paths, error strings, and control flow are preserved.
> 
> **Overview**
> Refactors export orchestration into smaller helpers without changing behavior.
> 
> In **`export_all`**, thumbnail handling and per-format export (try/catch, path assignment, error messages) move into **`_process_thumbnail`** and **`_process_format`**; the main loop only dispatches on format name.
> 
> In **`generate_exports`** (pipeline adapter), lazy pipeline imports and preset resolution move into **`_load_export_modules`** and **`_get_preset_for_export`**, mirroring the existing **`_load_pipeline`** pattern used for catalog registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59c353475aa64ef6d7b8f719d6d4c459b1a62849. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->