### PR TITLE
🧹 [code health improvement] Refactored build_pipeline_manifest for modularity

### DIFF
--- a/pipeline/manifest.py
+++ b/pipeline/manifest.py
@@ -75,6 +75,55 @@ DEFAULT_PACKS_DIR = "packs"
 DEFAULT_RENDERS_ROOT = "renders"
 
 
+def _format_pack_entry(entry: Any, catalog: 'AssetCatalog', total_assets_seen: set[str]) -> dict[str, Any]:
+    """Format an individual entry and update total assets seen."""
+    total_assets_seen.add(entry.asset_id)
+    asset = catalog.get(entry.asset_id)
+    return {
+        "asset_id":       entry.asset_id,
+        "asset_name":     asset.name if asset else entry.asset_id,
+        "asset_category": asset.category.value if asset else "",
+        "preset_id":      entry.preset_id,
+        "thumbnail":      entry.expected_outputs.get("thumbnail"),
+        "outputs": {
+            fmt: path
+            for fmt, path in entry.expected_outputs.items()
+            if fmt != "thumbnail"
+        },
+    }
+
+def _process_pack(
+    pack: 'PackDefinition',
+    catalog: 'AssetCatalog',
+    renders_root: str,
+    total_assets_seen: set[str],
+) -> dict[str, Any] | None:
+    """Process a single pack definition, build it, and format its entries."""
+    from pipeline.packager import build_pack
+
+    try:
+        pack_manifest = build_pack(
+            pack, catalog, renders_root=renders_root, strict_validation=False
+        )
+    except Exception as exc:
+        logger.error("Skipping pack %r – build_pack failed: %s", pack.pack_id, exc)
+        return None
+
+    entries = [
+        _format_pack_entry(entry, catalog, total_assets_seen)
+        for entry in pack_manifest.entries
+    ]
+
+    logger.info("build_pipeline_manifest: added pack %r (%d entries)", pack.pack_id, len(entries))
+    return {
+        "pack_id":         pack.pack_id,
+        "title":           pack.title,
+        "theme":           pack.theme,
+        "target_platforms": pack.target_platforms,
+        "export_formats":  pack.export_formats,
+        "entries":         entries,
+    }
+
 def build_pipeline_manifest(
     packs: list['PackDefinition'],
     catalog: 'AssetCatalog',
@@ -97,46 +146,13 @@ def build_pipeline_manifest(
     dict
         The full manifest as a Python dict.
     """
-    from pipeline.packager import build_pack
-
     manifest_packs: list[dict[str, Any]] = []
     total_assets_seen: set[str] = set()
 
     for pack in packs:
-        try:
-            pack_manifest = build_pack(
-                pack, catalog, renders_root=renders_root, strict_validation=False
-            )
-        except Exception as exc:
-            logger.error("Skipping pack %r – build_pack failed: %s", pack.pack_id, exc)
-            continue
-
-        entries: list[dict[str, Any]] = []
-        for entry in pack_manifest.entries:
-            total_assets_seen.add(entry.asset_id)
-            asset = catalog.get(entry.asset_id)
-            entries.append({
-                "asset_id":       entry.asset_id,
-                "asset_name":     asset.name if asset else entry.asset_id,
-                "asset_category": asset.category.value if asset else "",
-                "preset_id":      entry.preset_id,
-                "thumbnail":      entry.expected_outputs.get("thumbnail"),
-                "outputs": {
-                    fmt: path
-                    for fmt, path in entry.expected_outputs.items()
-                    if fmt != "thumbnail"
-                },
-            })
-
-        manifest_packs.append({
-            "pack_id":         pack.pack_id,
-            "title":           pack.title,
-            "theme":           pack.theme,
-            "target_platforms": pack.target_platforms,
-            "export_formats":  pack.export_formats,
-            "entries":         entries,
-        })
-        logger.info("build_pipeline_manifest: added pack %r (%d entries)", pack.pack_id, len(entries))
+        processed = _process_pack(pack, catalog, renders_root, total_assets_seen)
+        if processed is not None:
+            manifest_packs.append(processed)
 
     return {
         "generated_at": datetime.now(timezone.utc).isoformat(),


### PR DESCRIPTION
🎯 What: Refactored build_pipeline_manifest in pipeline/manifest.py to be more modular.
💡 Why: The function was too long and nested; breaking it into smaller helpers improves readability and maintainability.
✅ Verification: Ran full test suite successfully and verified functionality is unchanged via manual inspection of code.
✨ Result: Code is cleaner and more modular.

---
*PR created automatically by Jules for task [10052732463543487571](https://jules.google.com/task/10052732463543487571) started by @FriskyDevelopments*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure structural refactor in manifest generation with preserved control flow and output fields; no auth, I/O contract, or business-rule changes.
> 
> **Overview**
> **`build_pipeline_manifest`** in `pipeline/manifest.py` is slimmed down by moving per-entry shaping and per-pack work into two module-level helpers.
> 
> **`_format_pack_entry`** builds each manifest entry dict (asset metadata, thumbnail, non-thumbnail outputs) and still records `asset_id` in the shared `total_assets_seen` set. **`_process_pack`** owns the `build_pack` call, error logging/skip on failure, entry list comprehension, success log line, and the pack-level dict; it returns `None` when a pack is skipped.
> 
> The main loop now only calls `_process_pack` and appends non-`None` results—same manifest shape and skip-on-error behavior as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0f803e0647766852803cb63b8873689670a6b64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->