### PR TITLE
⚡ Bolt: Cache get_settings to prevent redundant parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -57,3 +57,6 @@
 ## 2024-07-04 - Cryptographic Derivation Caching in Auth Paths
 **Learning:** Found that generating an HMAC secret key from a constant bot token inside `_compute_hash` was unnecessarily repeating cryptographic (SHA256) operations on every single WebApp authentication request. This CPU overhead limits throughput on high-traffic auth paths.
 **Action:** Extract the secret key derivation into a separate helper and cache it (e.g., via `@functools.lru_cache(maxsize=1)`) since the bot token is constant for the lifetime of the process. Also minimize allocations by filtering keys explicitly in loops instead of constructing intermediate dictionaries.
+## 2024-07-05 - AppSettings Redundant Environment Parsing
+**Learning:** Found that `stixmagic.settings.get_settings()` is called frequently across the codebase (e.g. on every database operation or request). By not caching the result, the application repeatedly parses environment variables and allocates new `AppSettings` dataclass instances, creating unnecessary overhead and memory allocation churn.
+**Action:** Always use `@functools.lru_cache(maxsize=1)` on global configuration factory functions to ensure settings are only parsed once per process lifecycle, preventing redundant allocations on high-traffic paths.

--- a/stixmagic/settings.py
+++ b/stixmagic/settings.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import functools
 from dataclasses import dataclass
 
 from dotenv import load_dotenv
@@ -118,6 +119,7 @@ def _resolve_env(*names: str) -> str:
     return ""
 
 
+@functools.lru_cache(maxsize=1)
 def get_settings() -> AppSettings:
     """
     Builds an AppSettings instance by reading and normalizing configuration from environment variables.

--- a/tests/test_stixmagic_settings.py
+++ b/tests/test_stixmagic_settings.py
@@ -24,6 +24,7 @@ class TestGetSettings(unittest.TestCase):
         if 'TELEGRAM_BOT_TOKEN' not in env and 'BOT_TOKEN_DEV' not in env and 'BOT_TOKEN_PROD' not in env:
             env['TELEGRAM_BOT_TOKEN'] = 'dummy'
         with patch.dict(os.environ, env, clear=True):
+            mod.get_settings.cache_clear()
             return mod.get_settings()
 
     def test_basic_settings_loaded(self):


### PR DESCRIPTION
💡 **What**: Added `@functools.lru_cache(maxsize=1)` to the `get_settings()` function in `stixmagic/settings.py`, and correctly cleared the cache during testing mock phases.\n\n🎯 **Why**: Identified through analysis that `get_settings()` is called on every database connection and API request to parse environment variables and spawn new `AppSettings` dataclass instances. Caching this global singleton prevents repeated I/O and memory churn, heavily reducing overhead on fast paths.\n\n📊 **Impact**: Expected to slightly decrease memory allocation overhead and completely remove repeated CPU cost of parsing the environment variables on every database hit.\n\n🔬 **Measurement**: Verified by ensuring all tests pass successfully without leaking mocked environment states between isolated unit tests, showing the implementation functions as correctly as a singleton but without redundant evaluations.

---
*PR created automatically by Jules for task [17655656738387675784](https://jules.google.com/task/17655656738387675784) started by @FriskyDevelopments*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved application startup efficiency by caching configuration settings after their initial load.

* **Bug Fixes**
  * Prevented configuration values from being unnecessarily re-read during runtime.
  * Improved reliability of environment-based configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->